### PR TITLE
include LICENSE in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,4 @@ graft scs/linsys/direct
 graft scs/linsys/direct/external
 graft scs/linsys/indirect
 graft scs/linsys/gpu
-
+include LICENSE


### PR DESCRIPTION
Right now the files made by `setup.py sdist` don't include the `LICENSE` file; this makes them do so.