### PR TITLE
Python linsys solver.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ python/.coverage
 python/build/
 python/cover/
 python_dist
+build
+dist
 linsys_dense/out
 out
 .swo
@@ -44,3 +46,4 @@ out
 *.class
 *.dylib
 *.jar
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
       sudo apt-get install liblapack-dev;
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew update;
-      brew install pyenv-virtualenv gcc;
+      brew install pyenv-virtualenv gcc openssl;
       pyenv install $PYTHON;
       export PYENV_VERSION=$PYTHON;
       export PATH="/Users/travis/.pyenv/shims:${PATH}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,17 @@ matrix:
   - os: osx
     language: generic
     env: PYTHON=3.6.0
-  - os: linux 
-    language: python 
+  - os: linux
+    language: python
     python: "2.7"
   - os: linux
-    language: python 
+    language: python
     python: "3.4"
   - os: linux
-    language: python 
+    language: python
     python: "3.5"
   - os: linux
-    language: python 
+    language: python
     python: "3.6"
 
 before_install:
@@ -31,6 +31,8 @@ before_install:
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew update;
       brew install pyenv-virtualenv gcc openssl;
+      export CFLAGS="-I$(brew --prefix openssl)/include ${CFLAGS}"
+      export LDFLAGS="-L$(brew --prefix openssl)/lib ${LDFLAGS}"
       pyenv install $PYTHON;
       export PYENV_VERSION=$PYTHON;
       export PATH="/Users/travis/.pyenv/shims:${PATH}";
@@ -49,4 +51,3 @@ script:
 notifications:
   email:
     - bodonoghue85@gmail.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - python setup.py install
 
 script:
-  - cd test && nosetests test_scs_basic.py test_scs_rand.py test_scs_sdp.py
+  - cd test && nosetests test_scs_basic.py test_scs_rand.py test_scs_sdp.py test_scs_python_linsys.py
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_install:
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew update;
       brew install pyenv-virtualenv gcc openssl;
-      export CFLAGS="-I$(brew --prefix openssl)/include ${CFLAGS}"
-      export LDFLAGS="-L$(brew --prefix openssl)/lib ${LDFLAGS}"
+      export CFLAGS="-I$(brew --prefix openssl)/include ${CFLAGS}";
+      export LDFLAGS="-L$(brew --prefix openssl)/lib ${LDFLAGS}";
       pyenv install $PYTHON;
       export PYENV_VERSION=$PYTHON;
       export PATH="/Users/travis/.pyenv/shims:${PATH}";

--- a/python_linsys/private.c
+++ b/python_linsys/private.c
@@ -5,9 +5,9 @@
 
 // The following are shared with scsmodule.c, which
 // sets the callbacks.
-extern PyObject *solve_lin_sys_cb;
-extern PyObject *accum_by_a_cb;
-extern PyObject *accum_by_atrans_cb;
+extern PyObject *scs_solve_lin_sys_cb;
+extern PyObject *scs_accum_by_a_cb;
+extern PyObject *scs_accum_by_atrans_cb;
 extern int scs_get_float_type(void);
 
 char *SCS(get_lin_sys_method)(const ScsMatrix *A, const ScsSettings *stgs) {
@@ -48,7 +48,7 @@ void SCS(accum_by_atrans)(const ScsMatrix *A, ScsLinSysWork *p,
   PyArray_ENABLEFLAGS((PyArrayObject *)y_np, NPY_ARRAY_OWNDATA);
 
   PyObject *arglist = Py_BuildValue("(OO)", x_np, y_np);
-  PyObject_CallObject(accum_by_atrans_cb, arglist);
+  PyObject_CallObject(scs_accum_by_atrans_cb, arglist);
 }
 
 void SCS(accum_by_a)(const ScsMatrix *A, ScsLinSysWork *p, const scs_float *x,
@@ -68,7 +68,7 @@ void SCS(accum_by_a)(const ScsMatrix *A, ScsLinSysWork *p, const scs_float *x,
   PyArray_ENABLEFLAGS((PyArrayObject *)y_np, NPY_ARRAY_OWNDATA);
 
   PyObject *arglist = Py_BuildValue("(OO)", x_np, y_np);
-  PyObject_CallObject(accum_by_a_cb, arglist);
+  PyObject_CallObject(scs_accum_by_a_cb, arglist);
 }
 
 ScsLinSysWork *SCS(init_lin_sys_work)(const ScsMatrix *A,
@@ -98,7 +98,7 @@ scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
   PyArray_ENABLEFLAGS((PyArrayObject *)s_np, NPY_ARRAY_OWNDATA);
 
   PyObject *arglist = Py_BuildValue("(OOi)", b_np, s_np, iter);
-  PyObject_CallObject(solve_lin_sys_cb, arglist);
+  PyObject_CallObject(scs_solve_lin_sys_cb, arglist);
 
   p->total_solve_time += SCS(tocq)(&linsys_timer);
   return 0;

--- a/python_linsys/private.c
+++ b/python_linsys/private.c
@@ -8,7 +8,7 @@
 extern PyObject *solve_lin_sys_cb;
 extern PyObject *accum_by_a_cb;
 extern PyObject *accum_by_atrans_cb;
-extern int get_float_type(void);
+extern int scs_get_float_type(void);
 
 char *SCS(get_lin_sys_method)(const ScsMatrix *A, const ScsSettings *stgs) {
   char *str = (char *)scs_malloc(sizeof(char) * 128);
@@ -33,7 +33,7 @@ void SCS(free_lin_sys_work)(ScsLinSysWork *p) {
 
 void SCS(accum_by_atrans)(const ScsMatrix *A, ScsLinSysWork *p,
                           const scs_float *x, scs_float *y) {
-  int scs_float_type = get_float_type();
+  int scs_float_type = scs_get_float_type();
 
   npy_intp veclen[1];
   veclen[0] = A->m;
@@ -53,7 +53,7 @@ void SCS(accum_by_atrans)(const ScsMatrix *A, ScsLinSysWork *p,
 
 void SCS(accum_by_a)(const ScsMatrix *A, ScsLinSysWork *p, const scs_float *x,
                      scs_float *y) {
-  int scs_float_type = get_float_type();
+  int scs_float_type = scs_get_float_type();
 
   npy_intp veclen[1];
   veclen[0] = A->n;
@@ -88,7 +88,7 @@ scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
 
   npy_intp veclen[1];
   veclen[0] = A->n + A->m;
-  int scs_float_type = get_float_type();
+  int scs_float_type = scs_get_float_type();
   PyObject *b_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, b);
   PyObject *s_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, s);
 

--- a/python_linsys/private.c
+++ b/python_linsys/private.c
@@ -73,7 +73,7 @@ void SCS(accum_by_a)(const ScsMatrix *A, ScsLinSysWork *p, const scs_float *x,
 
 ScsLinSysWork *SCS(init_lin_sys_work)(const ScsMatrix *A,
                                       const ScsSettings *stgs) {
-  import_array(); // TODO: Move this somewhere else?
+  _import_array(); // TODO: Move this somewhere else?
 
   ScsLinSysWork *p = (ScsLinSysWork *)scs_calloc(1, sizeof(ScsLinSysWork));
   p->total_solve_time = 0;

--- a/python_linsys/private.c
+++ b/python_linsys/private.c
@@ -1,0 +1,105 @@
+#include <Python.h>
+#include "numpy/arrayobject.h"
+#include "common.h"
+#include "private.h"
+
+// The following are shared with scsmodule.c, which
+// sets the callbacks.
+extern PyObject *solve_lin_sys_cb;
+extern PyObject *accum_by_a_cb;
+extern PyObject *accum_by_atrans_cb;
+extern int get_float_type(void);
+
+char *SCS(get_lin_sys_method)(const ScsMatrix *A, const ScsSettings *stgs) {
+  char *str = (char *)scs_malloc(sizeof(char) * 128);
+  sprintf(str, "Python");
+  return str;
+}
+
+char *SCS(get_lin_sys_summary)(ScsLinSysWork *p, const ScsInfo *info) {
+  char *str = (char *)scs_malloc(sizeof(char) * 128);
+  sprintf(str,
+          "\tLin-sys: avg solve time: %1.2es\n",
+          p->total_solve_time / (info->iter + 1) / 1e3);
+  p->total_solve_time = 0;
+  return str;
+}
+
+void SCS(free_lin_sys_work)(ScsLinSysWork *p) {
+  if (p) {
+    scs_free(p);
+  }
+}
+
+void SCS(accum_by_atrans)(const ScsMatrix *A, ScsLinSysWork *p,
+                          const scs_float *x, scs_float *y) {
+  int scs_float_type = get_float_type();
+
+  npy_intp veclen[1];
+  veclen[0] = A->m;
+  PyObject *x_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, x);
+
+  veclen[0] = A->n;
+  PyObject *y_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, y);
+
+  // TODO: Should we not let numpy own the data since we're just
+  // using this in a callback?
+  PyArray_ENABLEFLAGS((PyArrayObject *)x_np, NPY_ARRAY_OWNDATA);
+  PyArray_ENABLEFLAGS((PyArrayObject *)y_np, NPY_ARRAY_OWNDATA);
+
+  PyObject *arglist = Py_BuildValue("(OO)", x_np, y_np);
+  PyObject_CallObject(accum_by_atrans_cb, arglist);
+}
+
+void SCS(accum_by_a)(const ScsMatrix *A, ScsLinSysWork *p, const scs_float *x,
+                     scs_float *y) {
+  int scs_float_type = get_float_type();
+
+  npy_intp veclen[1];
+  veclen[0] = A->n;
+  PyObject *x_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, x);
+
+  veclen[0] = A->m;
+  PyObject *y_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, y);
+
+  // TODO: Should we not let numpy own the data since we're just
+  // using this in a callback?
+  PyArray_ENABLEFLAGS((PyArrayObject *)x_np, NPY_ARRAY_OWNDATA);
+  PyArray_ENABLEFLAGS((PyArrayObject *)y_np, NPY_ARRAY_OWNDATA);
+
+  PyObject *arglist = Py_BuildValue("(OO)", x_np, y_np);
+  PyObject_CallObject(accum_by_a_cb, arglist);
+}
+
+ScsLinSysWork *SCS(init_lin_sys_work)(const ScsMatrix *A,
+                                      const ScsSettings *stgs) {
+  import_array(); // TODO: Move this somewhere else?
+
+  ScsLinSysWork *p = (ScsLinSysWork *)scs_calloc(1, sizeof(ScsLinSysWork));
+  p->total_solve_time = 0;
+  return p;
+}
+
+scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
+                           ScsLinSysWork *p, scs_float *b, const scs_float *s,
+                           scs_int iter) {
+  SCS(timer) linsys_timer;
+  SCS(tic)(&linsys_timer);
+
+  npy_intp veclen[1];
+  veclen[0] = A->n + A->m;
+  int scs_float_type = get_float_type();
+  PyObject *b_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, b);
+  PyObject *s_np = PyArray_SimpleNewFromData(1, veclen, scs_float_type, s);
+
+  // TODO: Should we not let numpy own the data since we're just
+  // using this in a callback?
+  PyArray_ENABLEFLAGS((PyArrayObject *)b_np, NPY_ARRAY_OWNDATA);
+  PyArray_ENABLEFLAGS((PyArrayObject *)s_np, NPY_ARRAY_OWNDATA);
+
+  PyObject *arglist = Py_BuildValue("(OOi)", b_np, s_np, iter);
+  PyObject_CallObject(solve_lin_sys_cb, arglist);
+
+  p->total_solve_time += SCS(tocq)(&linsys_timer);
+  return 0;
+}

--- a/python_linsys/private.h
+++ b/python_linsys/private.h
@@ -1,0 +1,17 @@
+#ifndef PRIV_H_GUARD
+#define PRIV_H_GUARD
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "scs.h"
+
+struct SCS_LIN_SYS_WORK {
+  scs_float total_solve_time;
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ def install_scs(**kwargs):
   _scs_indirect = Extension(
       name='_scs_indirect',
       sources=sources + glob('scs/linsys/indirect/*.c'),
-      define_macros=define_macros + [('INDIRECT', None)],
+      define_macros=list(define_macros) + [('INDIRECT', None)],
       include_dirs=include_dirs + ['scs/linsys/indirect/'],
       libraries=list(libraries),
       extra_compile_args=list(extra_compile_args))

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,16 @@ def install_scs(**kwargs):
       libraries=list(libraries),
       extra_compile_args=list(extra_compile_args))
 
-  ext_modules = [_scs_direct, _scs_indirect]
+  _scs_python = Extension(
+      name='_scs_python',
+      sources=sources + glob('python_linsys/*.c'),
+      define_macros=list(define_macros) + [('PYTHON_LINSYS', None)],
+      include_dirs=include_dirs + ['python_linsys'],
+      libraries=list(libraries),
+      extra_compile_args=list(extra_compile_args))
+
+
+  ext_modules = [_scs_direct, _scs_indirect, _scs_python]
 
   if args.gpu:
     _scs_gpu = Extension(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21,11 +21,14 @@ def solve(probdata, cone, **kwargs):
   if not probdata or not cone:
     raise TypeError('Missing data or cone information')
 
-  if 'A' not in probdata or 'b' not in probdata or 'c' not in probdata:
-    raise TypeError('Missing one or more of A, b, c from data dictionary')
-  A = probdata['A']
+  if 'b' not in probdata or 'c' not in probdata:
+    raise TypeError('Missing one or more of b, c from data dictionary')
+
   b = probdata['b']
   c = probdata['c']
+
+  m = len(b)
+  n = len(c)
 
   warm = {}
   if 'x' in probdata:
@@ -35,22 +38,30 @@ def solve(probdata, cone, **kwargs):
   if 's' in probdata:
     warm['s'] = probdata['s']
 
-  if A is None or b is None or c is None:
+  if b is None or c is None:
     raise TypeError('Incomplete data specification')
-  if not sparse.issparse(A):
-    raise TypeError('A is required to be a sparse matrix')
-  if not sparse.isspmatrix_csc(A):
-    warn('Converting A to a CSC (compressed sparse column) matrix; may take a '
-         'while.')
-    A = A.tocsc()
+
+  use_python_linsys = kwargs.pop('use_python_linsys', False)
+  if use_python_linsys:
+    # Create an empty placeholder A matrix that is never used.
+    A = sparse.csc_matrix((m,n))
+  else:
+    if 'A' not in probdata:
+      raise TypeError('Missing A from data dictionary')
+    A = probdata['A']
+
+    if not sparse.issparse(A):
+      raise TypeError('A is required to be a sparse matrix')
+    if not sparse.isspmatrix_csc(A):
+      warn('Converting A to a CSC (compressed sparse column) matrix; may take a '
+           'while.')
+      A = A.tocsc()
 
   if sparse.issparse(b):
     b = b.todense()
 
   if sparse.issparse(c):
     c = c.todense()
-
-  m, n = A.shape
 
   Adata, Aindices, Acolptr = A.data, A.indices, A.indptr
   if kwargs.pop('gpu', False):  # False by default
@@ -65,6 +76,12 @@ def solve(probdata, cone, **kwargs):
     import _scs_indirect
     return _scs_indirect.csolve((m, n), Adata, Aindices, Acolptr, b, c, cone,
                                 warm, **kwargs)
+
+  if use_python_linsys:
+    import _scs_python
+    return _scs_python.csolve(
+        (m, n), Adata, Aindices, Acolptr, b, c, cone,
+        warm, **kwargs)
 
   return _scs_direct.csolve((m, n), Adata, Aindices, Acolptr, b, c, cone, warm,
                             **kwargs)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -41,8 +41,8 @@ def solve(probdata, cone, **kwargs):
   if b is None or c is None:
     raise TypeError('Incomplete data specification')
 
-  use_python_linsys = kwargs.pop('use_python_linsys', False)
-  if use_python_linsys:
+  linsys_cbs = kwargs.get('linsys_cbs', None)
+  if linsys_cbs:
     # Create an empty placeholder A matrix that is never used.
     A = sparse.csc_matrix((m,n))
   else:
@@ -77,7 +77,7 @@ def solve(probdata, cone, **kwargs):
     return _scs_indirect.csolve((m, n), Adata, Aindices, Acolptr, b, c, cone,
                                 warm, **kwargs)
 
-  if use_python_linsys:
+  if linsys_cbs:
     import _scs_python
     return _scs_python.csolve(
         (m, n), Adata, Aindices, Acolptr, b, c, cone,

--- a/src/scsmodule.c
+++ b/src/scsmodule.c
@@ -34,9 +34,9 @@ struct ScsPyData {
 };
 
 
-PyObject *solve_lin_sys_cb = SCS_NULL;
-PyObject *accum_by_a_cb = SCS_NULL;
-PyObject *accum_by_atrans_cb = SCS_NULL;
+PyObject *scs_solve_lin_sys_cb = SCS_NULL;
+PyObject *scs_accum_by_a_cb = SCS_NULL;
+PyObject *scs_accum_by_atrans_cb = SCS_NULL;
 
 /* Note, Python3.x may require special handling for the scs_int and scs_float
  * types. */
@@ -335,7 +335,7 @@ static PyObject *csolve(PyObject *self, PyObject *args, PyObject *kwargs) {
           &(d->stgs->cg_rate), &(d->stgs->alpha), &(d->stgs->rho_x),
           &(d->stgs->acceleration_lookback),
           &(d->stgs->write_data_filename),
-          &solve_lin_sys_cb, &accum_by_a_cb, &accum_by_atrans_cb)) {
+          &scs_solve_lin_sys_cb, &scs_accum_by_a_cb, &scs_accum_by_atrans_cb)) {
     PySys_WriteStderr("error parsing inputs\n");
     return SCS_NULL;
   }
@@ -449,18 +449,18 @@ static PyObject *csolve(PyObject *self, PyObject *args, PyObject *kwargs) {
   }
 
 #ifdef PYTHON_LINSYS
-  if (!PyCallable_Check(solve_lin_sys_cb)) {
-    PyErr_SetString(PyExc_ValueError, "solve_lin_sys_cb not a valid callback");
+  if (!PyCallable_Check(scs_solve_lin_sys_cb)) {
+    PyErr_SetString(PyExc_ValueError, "scs_solve_lin_sys_cb not a valid callback");
     return SCS_NULL;
   }
 
-  if (!PyCallable_Check(accum_by_a_cb)) {
-    PyErr_SetString(PyExc_ValueError, "accum_by_a_cb not a valid callback");
+  if (!PyCallable_Check(scs_accum_by_a_cb)) {
+    PyErr_SetString(PyExc_ValueError, "scs_accum_by_a_cb not a valid callback");
     return SCS_NULL;
   }
 
-  if (!PyCallable_Check(accum_by_atrans_cb)) {
-    PyErr_SetString(PyExc_ValueError, "accum_by_atrans_cb not a valid callback");
+  if (!PyCallable_Check(scs_accum_by_atrans_cb)) {
+    PyErr_SetString(PyExc_ValueError, "scs_accum_by_atrans_cb not a valid callback");
     return SCS_NULL;
   }
 #endif

--- a/src/scsmodule.c
+++ b/src/scsmodule.c
@@ -40,7 +40,7 @@ PyObject *accum_by_atrans_cb = SCS_NULL;
 
 /* Note, Python3.x may require special handling for the scs_int and scs_float
  * types. */
-int get_int_type(void) {
+int scs_get_int_type(void) {
   switch (sizeof(scs_int)) {
     case 1:
       return NPY_INT8;
@@ -55,7 +55,7 @@ int get_int_type(void) {
   }
 }
 
-int get_float_type(void) {
+int scs_get_float_type(void) {
   switch (sizeof(scs_float)) {
     case 2:
       return NPY_FLOAT16;
@@ -126,7 +126,7 @@ static scs_int get_warm_start(char *key, scs_float **x, scs_int l,
       PySys_WriteStderr("Error parsing warm-start input\n");
       return 0;
     } else {
-      PyArrayObject *px0 = get_contiguous(x0, get_float_type());
+      PyArrayObject *px0 = get_contiguous(x0, scs_get_float_type());
       memcpy(*x, (scs_float *)PyArray_DATA(px0), l * sizeof(scs_float));
       Py_DECREF(px0);
       return 1;
@@ -258,8 +258,8 @@ static PyObject *csolve(PyObject *self, PyObject *args, PyObject *kwargs) {
   PyObject *verbose = SCS_NULL;
   PyObject *normalize = SCS_NULL;
   /* get the typenum for the primitive scs_int and scs_float types */
-  int scs_int_type = get_int_type();
-  int scs_float_type = get_float_type();
+  int scs_int_type = scs_get_int_type();
+  int scs_float_type = scs_get_float_type();
   struct ScsPyData ps = {
       SCS_NULL, SCS_NULL, SCS_NULL, SCS_NULL, SCS_NULL,
   };

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -1,0 +1,92 @@
+from __future__ import print_function
+import platform
+## import utilities to generate random cone probs:
+import sys
+import gen_random_cone_prob as tools
+
+
+def import_error(msg):
+  print()
+  print('## IMPORT ERROR:' + msg)
+  print()
+
+
+try:
+  from nose.tools import assert_raises, assert_almost_equals
+except ImportError:
+  import_error('Please install nose to run tests.')
+  raise
+
+try:
+  import scs
+except ImportError:
+  import_error('You must install the scs module before running tests.')
+  raise
+
+try:
+  import numpy as np
+except ImportError:
+  import_error('Please install numpy.')
+  raise
+
+try:
+  import scipy.sparse as sp
+  import scipy.sparse.linalg as sla
+except ImportError:
+  import_error('Please install scipy.')
+  raise
+
+
+def check_solution(solution, expected):
+  assert_almost_equals(solution, expected, places=2)
+
+
+def assert_(str1, str2):
+  if (str1 != str2):
+    print('assert failure: %s != %s' % (str1, str2))
+  assert str1 == str2
+
+
+np.random.seed(0)
+num_probs = 50
+
+K = {
+    'f': 10,
+    'l': 25,
+    'q': [5, 10, 0, 1],
+    's': [2, 1, 2, 0, 1],
+    'ep': 0,
+    'ed': 0,
+    'p': [0.25, -0.75, 0.33, -0.33, 0.2]
+}
+m = tools.get_scs_cone_dims(K)
+
+def test_python_linsys():
+  for i in range(num_probs):
+    data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
+
+    A = data['A']
+    ncon_cone, nz_cone = A.shape
+    rho_x = 1e-3
+    M = sp.bmat([[rho_x*sp.eye(nz_cone), A.T], [A, -sp.eye(ncon_cone)]])
+    Msolve = sla.factorized(M)
+
+    def solve_lin_sys_cb(b, s, i):
+        b[:] = Msolve(b)
+
+    def accum_by_a_cb(x, y):
+        y += A.dot(x)
+
+    def accum_by_atrans_cb(x, y):
+        y += A.T.dot(x)
+
+    sol = scs.solve(
+        data, K, verbose=True, use_indirect=False,
+        normalize=False, use_python_linsys=True,
+        rho_x=rho_x,
+        linsys_cbs=(solve_lin_sys_cb,accum_by_a_cb,accum_by_atrans_cb),
+        max_iters=int(1e5), eps=1e-5,
+    )
+
+    yield check_solution, np.dot(data['c'], sol['x']), p_star
+    yield check_solution, np.dot(-data['b'], sol['y']), p_star

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -86,8 +86,7 @@ def test_python_linsys():
 
     sol = scs.solve(
         data, K, verbose=True, use_indirect=False,
-        normalize=False, use_python_linsys=True,
-        rho_x=rho_x,
+        normalize=False, rho_x=rho_x,
         linsys_cbs=(solve_lin_sys_cb,accum_by_a_cb,accum_by_atrans_cb),
         max_iters=int(1e5), eps=1e-5,
     )

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -4,9 +4,9 @@ import platform
 import sys
 import gen_random_cone_prob as tools
 
-if platform.system() == 'Windows':
-  print('Skipping Python linear system tests on Windows')
-  sys.exit(0)
+# if platform.system() == 'Windows':
+#   print('Skipping Python linear system tests on Windows')
+#   sys.exit(0)
 
 
 def import_error(msg):

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -4,6 +4,10 @@ import platform
 import sys
 import gen_random_cone_prob as tools
 
+if platform.system() == 'Windows':
+  print('Skipping Python linear system tests on Windows')
+  sys.exit(0)
+
 
 def import_error(msg):
   print()


### PR DESCRIPTION
This is a nearly-finished PR for a linear system solver that calls back up into Python. It passes an empty `A` matrix into SCS and defers all operations involving `A` to Python. Here is some of the remaining work (if you're fine with the core content of this PR, it may make sense to merge it in sooner and move some of these to the issue tracker)

+ [ ] Add support for other precision.
+ [ ] Decide if anything else should be passed back up to Python.
+ [ ] Add normalization. 
+ [ ] Add some docs and a description somewhere.
+ [ ] Add more checks to the functions passed in to make sure they are reasonable/take the correct number of arguments since otherwise errors coming from C calling back into Python can be uninformative/unnecessarily long
+ [ ] Windows support.

I've added a simple test in the same format as the other tests in `test/test_scs_python_linsys.py` and here's an example use of the interface:

```Python
ncon_cone, nz_cone = A.shape
rho = 1e-3
M = sp.bmat([[rho*sp.eye(nz_cone), A.T], [A, -sp.eye(ncon_cone)]])
Msolve = sla.factorized(M)

def solve_lin_sys_cb(b, s, i):
    b[:] = Msolve(b)

def accum_by_a_cb(x, y):
    y += A.dot(x)

def accum_by_atrans_cb(x, y):
    y += A.T.dot(x)

sol = scs.solve(
    data, cones, verbose=True, use_indirect=False,
    normalize=False, max_iters=10,
    linsys_cbs=(solve_lin_sys_cb,accum_by_a_cb,accum_by_atrans_cb)
)
```