### PR TITLE
remove scipy from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ def install_scs(**kwargs):
       packages=['scs'],
       ext_modules=ext_modules,
       cmdclass={'build_ext': build_ext_scs},
-      setup_requires=['numpy >= 1.7', 'scipy >= 0.13.2'],
+      setup_requires=['numpy >= 1.7'],
       install_requires=['numpy >= 1.7', 'scipy >= 0.13.2'],
       license='MIT',
       zip_safe=False,


### PR DESCRIPTION
I don't see any reason why scipy should be needed in `setup_requires`. If there's not one I'm missing, it's not a huge deal, but it makes our conda-forge packaging a little more awkward to have it there.