### PR TITLE
Switch from nosetests to pytest

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,6 +27,5 @@ build_script:
   - python setup.py install
 
 test_script:
-  - python test/solve_random_cone_prob.py
   - pytest test/
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,14 +20,13 @@ environment:
 build_script:
   - '%CONDAPATH%\Scripts\conda config --set always_yes yes'
   - '%CONDAPATH%\Scripts\conda update conda'
-  - '%CONDAPATH%\Scripts\conda create -p C:\pythontest python=%PYVER% numpy scipy nose'
+  - '%CONDAPATH%\Scripts\conda create -p C:\pythontest python=%PYVER% numpy scipy pytest'
   - '%CONDAPATH%\Scripts\activate C:\pythontest'
   - where python
   - git submodule update --init --recursive
   - python setup.py install
 
 test_script:
-  - cd test
-  - python solve_random_cone_prob.py
-  - nosetests
+  - python test/solve_random_cone_prob.py
+  - pytest test/
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ out
 *.dylib
 *.jar
 *.egg-info
+*.ipynb_checkpoints/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get install liblapack-dev;
       pip install --upgrade pip;
-      pip install numpy scipy nose;
+      pip install numpy scipy pytest;
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew update;
       brew install pyenv-virtualenv gcc openssl;
@@ -47,7 +47,7 @@ before_install:
       pyenv virtualenv testenv;
       python --version;
       sudo pip install --upgrade pip;
-      sudo pip install numpy scipy nose;
+      sudo pip install numpy scipy pytest;
     fi
 
 install:
@@ -57,7 +57,7 @@ install:
       sudo python setup.py install;
     fi
 script:
-  - cd test && nosetests test_scs_basic.py test_scs_rand.py test_scs_sdp.py test_scs_python_linsys.py
+  - pytest test/
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ To test that SCS installed correctly and you have `pytest` installed, run
 ```shell
 pytest
 ```
-you can also solve a random cone problem (without `pytest`) using
-```shell
-python test/solve_random_cone_prob.py
-```
 
 After installing the SCS interface, you import SCS using
 ```python

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ numpy and scipy to be installed. You can install the gpu interface using
 python setup.py install --scs --gpu
 ```
 
-To test that SCS installed correctly and you have `nose` installed, run
+To test that SCS installed correctly and you have `pytest` installed, run
 ```shell
-nosetests
+pytest
 ```
-you can also solve a random cone problem (without `nose`) using
+you can also solve a random cone problem (without `pytest`) using
 ```shell
 python test/solve_random_cone_prob.py
 ```

--- a/test/gen_random_cone_prob.py
+++ b/test/gen_random_cone_prob.py
@@ -1,6 +1,6 @@
 import scs
 import numpy as np
-from scipy import sparse, randn
+from scipy import sparse
 
 #############################################
 #      Generate random cone problems        #
@@ -9,13 +9,13 @@ from scipy import sparse, randn
 
 def gen_feasible(K, n, density):
   m = get_scs_cone_dims(K)
-  z = randn(m,)
+  z = np.random.randn(m,)
   y = proj_dual_cone(z, K)  # y = s - z;
   s = y - z  # s = proj_cone(z,K)
 
   A = sparse.rand(m, n, density, format='csc')
-  A.data = randn(A.nnz)
-  x = randn(n)
+  A.data = np.random.randn(A.nnz)
+  x = np.random.randn(n)
   c = -np.transpose(A).dot(y)
   b = A.dot(x) + s
 
@@ -26,31 +26,31 @@ def gen_feasible(K, n, density):
 def gen_infeasible(K, n):
   m = get_scs_cone_dims(K)
 
-  z = randn(m,)
+  z = np.random.randn(m,)
   y = proj_dual_cone(z, K)  # y = s - z;
-  A = randn(m, n)
+  A = np.random.randn(m, n)
   A = A - np.outer(y, np.transpose(A).dot(y)) / np.linalg.norm(y)**2  # dense...
 
-  b = randn(m)
+  b = np.random.randn(m)
   b = -b / np.dot(b, y)
 
-  data = {'A': sparse.csc_matrix(A), 'b': b, 'c': randn(n)}
+  data = {'A': sparse.csc_matrix(A), 'b': b, 'c': np.random.randn(n)}
   return data
 
 
 def gen_unbounded(K, n):
   m = get_scs_cone_dims(K)
 
-  z = randn(m)
+  z = np.random.randn(m)
   s = proj_cone(z, K)
-  A = randn(m, n)
-  x = randn(n)
+  A = np.random.randn(m, n)
+  x = np.random.randn(n)
   A = A - np.outer(s + A.dot(x), x) / np.linalg.norm(x)**2
   # dense...
-  c = randn(n)
+  c = np.random.randn(n)
   c = -c / np.dot(c, x)
 
-  data = {'A': sparse.csc_matrix(A), 'b': randn(m), 'c': c}
+  data = {'A': sparse.csc_matrix(A), 'b': np.random.randn(m), 'c': c}
   return data
 
 

--- a/test/solve_random_cone_prob.py
+++ b/test/solve_random_cone_prob.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 import scs
 import numpy as np
-from scipy import sparse, randn
+from scipy import sparse
 import gen_random_cone_prob as tools
 
 #############################################

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -10,9 +10,9 @@ def import_error(msg):
 
 
 try:
-  from nose.tools import assert_raises
+  import pytest
 except ImportError:
-  import_error('Please install nose to run tests.')
+  import_error('Please install pytest to run tests.')
   raise
 
 try:
@@ -83,17 +83,20 @@ if platform.python_version_tuple() < ('3', '0', '0'):
     check_solution, sol['x'][0], 0.5
 
 
-def check_keyword(error_type, keyword, value):
-  assert_raises(error_type, scs.solve, data, cone, **{keyword: value})
-
-
 def test_failures():
-  assert_raises, TypeError, scs.solve
-  assert_raises, ValueError, scs.solve, data, {'q': [4], 'l': -2}
+  with pytest.raises(TypeError):
+    scs.solve()
+
+  with pytest.raises(ValueError):
+    scs.solve(data, {'q': [4], 'l': -2})
+
   # disable this until win64 types figured out
-  # check_keyword, ValueError, 'max_iters', -1
+  # with pytest.raises(ValueError)
+    # scs.solve(data, cone, max_iters=-1)
+
   # python 2.6 and before just cast float to int
   if platform.python_version_tuple() >= ('2', '7', '0'):
-    check_keyword, TypeError, 'max_iters', 1.1
+    with pytest.raises(TypeError):
+      scs.solve(data, cone, max_iters=1.1)
 
-  check_failure, scs.solve(data, {'q': [1], 'l': 0})
+  check_failure(scs.solve(data, {'q': [1], 'l': 0}))

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -10,7 +10,7 @@ def import_error(msg):
 
 
 try:
-  from nose.tools import assert_raises, assert_almost_equals
+  from nose.tools import assert_raises
 except ImportError:
   import_error('Please install nose to run tests.')
   raise
@@ -23,6 +23,7 @@ except ImportError:
 
 try:
   import numpy as np
+  from numpy.testing import assert_almost_equal
 except ImportError:
   import_error('Please install numpy.')
   raise
@@ -44,7 +45,7 @@ FAIL = 'Failure'  # scs code for failure
 
 
 def check_solution(solution, expected):
-  assert_almost_equals(solution, expected, places=2)
+  assert_almost_equal(solution, expected, decimal=2)
 
 
 def check_failure(sol):

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -43,10 +43,6 @@ data = {'A': A, 'b': b, 'c': c}
 FAIL = 'Failure'  # scs code for failure
 
 
-def check_failure(sol):
-  assert sol['info']['status'] == FAIL
-
-
 @pytest.mark.parametrize("cone,use_indirect,expected",
   [
     ({'q': [], 'l': 2}, False, 1),
@@ -91,4 +87,5 @@ def test_failures():
     with pytest.raises(TypeError):
       scs.solve(data, {'q': [], 'l': 2}, max_iters=1.1)
 
-  check_failure(scs.solve(data, {'q': [1], 'l': 0}))
+  sol = scs.solve(data, {'q': [1], 'l': 0})
+  assert sol['info']['status'] == FAIL

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -52,7 +52,7 @@ FAIL = 'Failure'  # scs code for failure
   ]
 )
 def test_problems(cone, use_indirect, expected):
-  sol = scs.solve(data, cone=cone, use_indirect=use_indirect)
+  sol = scs.solve(data, cone=cone, use_indirect=use_indirect, verbose=False)
   assert_almost_equal(sol['x'][0], expected, decimal=2)
 
 
@@ -67,7 +67,7 @@ if platform.python_version_tuple() < ('3', '0', '0'):
     ]
   )
   def test_problems_with_longs(cone, use_indirect, expected):
-    sol = scs.solve(data, cone=cone, use_indirect=use_indirect)
+    sol = scs.solve(data, cone=cone, use_indirect=use_indirect, verbose=False)
     assert_almost_equal(sol['x'][0], expected, decimal=2)
 
 
@@ -87,5 +87,5 @@ def test_failures():
     with pytest.raises(TypeError):
       scs.solve(data, {'q': [], 'l': 2}, max_iters=1.1)
 
-  sol = scs.solve(data, {'q': [1], 'l': 0})
+  sol = scs.solve(data, {'q': [1], 'l': 0}, verbose=False)
   assert sol['info']['status'] == FAIL

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -53,17 +53,17 @@ def check_failure(sol):
 
 def test_problems():
   sol = scs.solve(data, cone, use_indirect=False)
-  yield check_solution, sol['x'][0], 1
+  check_solution, sol['x'][0], 1
 
   new_cone = {'q': [2], 'l': 0}
   sol = scs.solve(data, new_cone, use_indirect=False)
-  yield check_solution, sol['x'][0], 0.5
+  check_solution, sol['x'][0], 0.5
 
   sol = scs.solve(data, cone, use_indirect=True)
-  yield check_solution, sol['x'][0], 1
+  check_solution, sol['x'][0], 1
 
   sol = scs.solve(data, new_cone, use_indirect=True)
-  yield check_solution, sol['x'][0], 0.5
+  check_solution, sol['x'][0], 0.5
 
 
 if platform.python_version_tuple() < ('3', '0', '0'):
@@ -71,15 +71,15 @@ if platform.python_version_tuple() < ('3', '0', '0'):
   def test_problems_with_longs():
     new_cone = {'q': [], 'l': long(2)}
     sol = scs.solve(data, new_cone, use_indirect=False)
-    yield check_solution, sol['x'][0], 1
+    check_solution, sol['x'][0], 1
     sol = scs.solve(data, new_cone, use_indirect=True)
-    yield check_solution, sol['x'][0], 1
+    check_solution, sol['x'][0], 1
 
     new_cone = {'q': [long(2)], 'l': 0}
     sol = scs.solve(data, new_cone, use_indirect=False)
-    yield check_solution, sol['x'][0], 0.5
+    check_solution, sol['x'][0], 0.5
     sol = scs.solve(data, new_cone, use_indirect=True)
-    yield check_solution, sol['x'][0], 0.5
+    check_solution, sol['x'][0], 0.5
 
 
 def check_keyword(error_type, keyword, value):
@@ -87,12 +87,12 @@ def check_keyword(error_type, keyword, value):
 
 
 def test_failures():
-  yield assert_raises, TypeError, scs.solve
-  yield assert_raises, ValueError, scs.solve, data, {'q': [4], 'l': -2}
+  assert_raises, TypeError, scs.solve
+  assert_raises, ValueError, scs.solve, data, {'q': [4], 'l': -2}
   # disable this until win64 types figured out
-  # yield check_keyword, ValueError, 'max_iters', -1
+  # check_keyword, ValueError, 'max_iters', -1
   # python 2.6 and before just cast float to int
   if platform.python_version_tuple() >= ('2', '7', '0'):
-    yield check_keyword, TypeError, 'max_iters', 1.1
+    check_keyword, TypeError, 'max_iters', 1.1
 
-  yield check_failure, scs.solve(data, {'q': [1], 'l': 0})
+  check_failure, scs.solve(data, {'q': [1], 'l': 0})

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -40,12 +40,6 @@ def check_solution(solution, expected):
   assert_almost_equal(solution, expected, decimal=2)
 
 
-def assert_(str1, str2):
-  if (str1 != str2):
-    print('assert failure: %s != %s' % (str1, str2))
-  assert str1 == str2
-
-
 np.random.seed(0)
 num_probs = 50
 

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -137,8 +137,8 @@ def test_python_linsys():
         max_iters=int(1e5), eps=1e-5,
     )
 
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
     sol = scs.solve(
         data, K, verbose=False, use_indirect=False,
@@ -151,8 +151,8 @@ def test_python_linsys():
         max_iters=int(1e5), eps=1e-5,
     )
 
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
 # for i,c in zip(range(4), test_python_linsys()):
 #     print(i,c)

--- a/test/test_scs_python_linsys.py
+++ b/test/test_scs_python_linsys.py
@@ -16,12 +16,6 @@ def import_error(msg):
 
 
 try:
-  from nose.tools import assert_raises, assert_almost_equals
-except ImportError:
-  import_error('Please install nose to run tests.')
-  raise
-
-try:
   import scs
 except ImportError:
   import_error('You must install the scs module before running tests.')
@@ -29,6 +23,7 @@ except ImportError:
 
 try:
   import numpy as np
+  from numpy.testing import assert_almost_equal
 except ImportError:
   import_error('Please install numpy.')
   raise
@@ -42,7 +37,7 @@ except ImportError:
 
 
 def check_solution(solution, expected):
-  assert_almost_equals(solution, expected, places=2)
+  assert_almost_equal(solution, expected, decimal=2)
 
 
 def assert_(str1, str2):

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -58,7 +58,8 @@ num_infeas = 10
 
 opts = {
     'max_iters': 100000,
-    'eps': 1e-5
+    'eps': 1e-5,
+    'verbose': False,
 }  # better accuracy than default to ensure test pass
 K = {
     'f': 10,

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -12,6 +12,12 @@ def import_error(msg):
 
 
 try:
+  import pytest
+except ImportError:
+  import_error('Please install pytest to run tests.')
+  raise
+
+try:
   import scs
 except ImportError:
   import_error('You must install the scs module before running tests.')
@@ -29,10 +35,6 @@ try:
 except ImportError:
   import_error('Please install scipy.')
   raise
-
-
-def check_solution(solution, expected):
-  assert_almost_equal(solution, expected, decimal=2)
 
 
 def assert_(str1, str2):
@@ -70,30 +72,29 @@ K = {
 m = tools.get_scs_cone_dims(K)
 
 
-def test_feasible():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_feasible(use_indirect):
   for i in range(num_feas):
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
 
-    sol = scs.solve(data, K, use_indirect=False, **opts)
-    check_solution, np.dot(data['c'], sol['x']), p_star
-    check_solution, np.dot(-data['b'], sol['y']), p_star
-
-    sol = scs.solve(data, K, use_indirect=True, **opts)
-    check_solution, np.dot(data['c'], sol['x']), p_star
-    check_solution, np.dot(-data['b'], sol['y']), p_star
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    assert_almost_equal(np.dot(data['c'], sol['x']), p_star, decimal=2)
+    assert_almost_equal(np.dot(-data['b'], sol['y']), p_star, decimal=2)
 
 
-def test_infeasible():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_infeasible(use_indirect):
   for i in range(num_infeas):
     data = tools.gen_infeasible(K, n=m // 3)
 
-    check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
-    check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    check_infeasible(sol)
 
 
-def test_unbounded():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_unbounded(use_indirect):
   for i in range(num_unb):
     data = tools.gen_unbounded(K, n=m // 2)
 
-    check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
-    check_unbounded, scs.solve(data, K, use_indirect=True, **opts)
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    check_unbounded(sol)

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -12,12 +12,6 @@ def import_error(msg):
 
 
 try:
-  from nose.tools import assert_raises, assert_almost_equals
-except ImportError:
-  import_error('Please install nose to run tests.')
-  raise
-
-try:
   import scs
 except ImportError:
   import_error('You must install the scs module before running tests.')
@@ -25,6 +19,7 @@ except ImportError:
 
 try:
   import numpy as np
+  from numpy.testing import assert_almost_equal
 except ImportError:
   import_error('Please install numpy.')
   raise
@@ -37,7 +32,7 @@ except ImportError:
 
 
 def check_solution(solution, expected):
-  assert_almost_equals(solution, expected, places=2)
+  assert_almost_equal(solution, expected, decimal=2)
 
 
 def assert_(str1, str2):

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -80,25 +80,25 @@ def test_feasible():
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
 
     sol = scs.solve(data, K, use_indirect=False, **opts)
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
     sol = scs.solve(data, K, use_indirect=True, **opts)
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
 
 def test_infeasible():
   for i in range(num_infeas):
     data = tools.gen_infeasible(K, n=m // 3)
 
-    yield check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
-    yield check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
+    check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
+    check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
 
 
 def test_unbounded():
   for i in range(num_unb):
     data = tools.gen_unbounded(K, n=m // 2)
 
-    yield check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
-    yield check_unbounded, scs.solve(data, K, use_indirect=True, **opts)
+    check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
+    check_unbounded, scs.solve(data, K, use_indirect=True, **opts)

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -58,7 +58,8 @@ num_infeas = 10
 
 opts = {
     'max_iters': 100000,
-    'eps': 1e-5
+    'eps': 1e-5,
+    'verbose': False,
 }  # better accuracy than default to ensure test pass
 K = {
     'f': 10,

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -12,6 +12,12 @@ def import_error(msg):
 
 
 try:
+  import pytest
+except ImportError:
+  import_error('Please install pytest to run tests.')
+  raise
+
+try:
   import scs
 except ImportError:
   import_error('You must install the scs module before running tests.')
@@ -29,10 +35,6 @@ try:
 except ImportError:
   import_error('Please install scipy.')
   raise
-
-
-def check_solution(solution, expected):
-  assert_almost_equal(solution, expected, decimal=2)
 
 
 def assert_(str1, str2):
@@ -70,30 +72,29 @@ K = {
 m = tools.get_scs_cone_dims(K)
 
 
-def test_feasible():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_feasible(use_indirect):
   for i in range(num_feas):
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
 
-    sol = scs.solve(data, K, use_indirect=False, **opts)
-    check_solution, np.dot(data['c'], sol['x']), p_star
-    check_solution, np.dot(-data['b'], sol['y']), p_star
-
-    sol = scs.solve(data, K, use_indirect=True, **opts)
-    check_solution, np.dot(data['c'], sol['x']), p_star
-    check_solution, np.dot(-data['b'], sol['y']), p_star
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    assert_almost_equal(np.dot(data['c'], sol['x']), p_star, decimal=2)
+    assert_almost_equal(np.dot(-data['b'], sol['y']), p_star, decimal=2)
 
 
-def test_infeasible():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_infeasible(use_indirect):
   for i in range(num_infeas):
     data = tools.gen_infeasible(K, n=m // 3)
 
-    check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
-    check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    check_infeasible(sol)
 
 
-def test_unbounded():
+@pytest.mark.parametrize("use_indirect", [False, True])
+def test_unbounded(use_indirect):
   for i in range(num_unb):
     data = tools.gen_unbounded(K, n=m // 2)
 
-    check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
-    check_unbounded, scs.solve(data, K, use_indirect=True, **opts)
+    sol = scs.solve(data, K, use_indirect=use_indirect, **opts)
+    check_unbounded(sol)

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -12,12 +12,6 @@ def import_error(msg):
 
 
 try:
-  from nose.tools import assert_raises, assert_almost_equals
-except ImportError:
-  import_error('Please install nose to run tests.')
-  raise
-
-try:
   import scs
 except ImportError:
   import_error('You must install the scs module before running tests.')
@@ -25,6 +19,7 @@ except ImportError:
 
 try:
   import numpy as np
+  from numpy.testing import assert_almost_equal
 except ImportError:
   import_error('Please install numpy.')
   raise
@@ -37,7 +32,7 @@ except ImportError:
 
 
 def check_solution(solution, expected):
-  assert_almost_equals(solution, expected, places=2)
+  assert_almost_equal(solution, expected, decimal=2)
 
 
 def assert_(str1, str2):

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -80,25 +80,25 @@ def test_feasible():
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
 
     sol = scs.solve(data, K, use_indirect=False, **opts)
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
     sol = scs.solve(data, K, use_indirect=True, **opts)
-    yield check_solution, np.dot(data['c'], sol['x']), p_star
-    yield check_solution, np.dot(-data['b'], sol['y']), p_star
+    check_solution, np.dot(data['c'], sol['x']), p_star
+    check_solution, np.dot(-data['b'], sol['y']), p_star
 
 
 def test_infeasible():
   for i in range(num_infeas):
     data = tools.gen_infeasible(K, n=m // 3)
 
-    yield check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
-    yield check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
+    check_infeasible, scs.solve(data, K, use_indirect=False, **opts)
+    check_infeasible, scs.solve(data, K, use_indirect=True, **opts)
 
 
 def test_unbounded():
   for i in range(num_unb):
     data = tools.gen_unbounded(K, n=m // 2)
 
-    yield check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
-    yield check_unbounded, scs.solve(data, K, use_indirect=True, **opts)
+    check_unbounded, scs.solve(data, K, use_indirect=False, **opts)
+    check_unbounded, scs.solve(data, K, use_indirect=True, **opts)

--- a/test/test_solve_random_cone_prob.py
+++ b/test/test_solve_random_cone_prob.py
@@ -29,21 +29,22 @@ except ImportError:
 
 np.random.seed(1)
 
+# cone:
+K = {
+    'f': 10,
+    'l': 15,
+    'q': [5, 10, 0, 1],
+    's': [3, 4, 0, 0, 1],
+    'ep': 10,
+    'ed': 10,
+    'p': [-0.25, 0.5, 0.75, -0.33]
+}
+m = tools.get_scs_cone_dims(K)
+params = {'normalize': True, 'scale': 5, 'cg_rate': 2}
+
 @pytest.mark.parametrize("use_indirect,gpu", flags)
 def test_solve_feasible(use_indirect, gpu):
-  # cone:
-  K = {
-      'f': 10,
-      'l': 15,
-      'q': [5, 10, 0, 1],
-      's': [3, 4, 0, 0, 1],
-      'ep': 10,
-      'ed': 10,
-      'p': [-0.25, 0.5, 0.75, -0.33]
-  }
-  m = tools.get_scs_cone_dims(K)
   data, p_star = tools.gen_feasible(K, n=m // 3, density=0.01)
-  params = {'normalize': True, 'scale': 5, 'cg_rate': 2}
 
   sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
   x = sol['x']
@@ -55,33 +56,11 @@ def test_solve_feasible(use_indirect, gpu):
 
 @pytest.mark.parametrize("use_indirect,gpu", flags)
 def test_solve_infeasible(use_indirect, gpu):
-  K = {
-      'f': 10,
-      'l': 15,
-      'q': [5, 10, 0, 1],
-      's': [3, 4, 0, 0, 1],
-      'ep': 10,
-      'ed': 10,
-      'p': [-0.25, 0.5, 0.75, -0.33]
-  }
-  m = tools.get_scs_cone_dims(K)
   data = tools.gen_infeasible(K, n=m // 3)
-  params = {'normalize': True, 'scale': 0.5, 'cg_rate': 2}
   sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
 
 
 @pytest.mark.parametrize("use_indirect,gpu", flags)
 def test_solve_unbounded(use_indirect, gpu):
-  K = {
-      'f': 10,
-      'l': 15,
-      'q': [5, 10, 0, 1],
-      's': [3, 4, 0, 0, 1],
-      'ep': 10,
-      'ed': 10,
-      'p': [-0.25, 0.5, 0.75, -0.33]
-  }
-  m = tools.get_scs_cone_dims(K)
   data = tools.gen_unbounded(K, n=m // 3)
-  params = {'normalize': True, 'scale': 0.5, 'cg_rate': 2}
   sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)

--- a/test/test_solve_random_cone_prob.py
+++ b/test/test_solve_random_cone_prob.py
@@ -8,23 +8,29 @@ import gen_random_cone_prob as tools
 #  Uses scs to solve a random cone problem  #
 #############################################
 
-
-def main():
-  flags = [(False, False), (True, False)]
-  try:
-    import _scs_gpu
-    flags += [(True, True)]
-  except ImportError:
-    pass
-
-  for (use_indirect, gpu) in flags:
-    np.random.seed(1)
-    solve_feasible(use_indirect, gpu)
-    solve_infeasible(use_indirect, gpu)
-    solve_unbounded(use_indirect, gpu)
+def import_error(msg):
+  print()
+  print('## IMPORT ERROR:' + msg)
+  print()
 
 
-def solve_feasible(use_indirect, gpu):
+try:
+  import pytest
+except ImportError:
+  import_error('Please install pytest to run tests.')
+  raise
+
+flags = [(False, False), (True, False)]
+try:
+  import _scs_gpu
+  flags += [(True, True)]
+except ImportError:
+  pass
+
+np.random.seed(1)
+
+@pytest.mark.parametrize("use_indirect,gpu", flags)
+def test_solve_feasible(use_indirect, gpu):
   # cone:
   K = {
       'f': 10,
@@ -47,7 +53,8 @@ def solve_feasible(use_indirect, gpu):
   print('dual error = ', (-np.dot(data['b'], y) - p_star) / p_star)
 
 
-def solve_infeasible(use_indirect, gpu):
+@pytest.mark.parametrize("use_indirect,gpu", flags)
+def test_solve_infeasible(use_indirect, gpu):
   K = {
       'f': 10,
       'l': 15,
@@ -63,7 +70,8 @@ def solve_infeasible(use_indirect, gpu):
   sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
 
 
-def solve_unbounded(use_indirect, gpu):
+@pytest.mark.parametrize("use_indirect,gpu", flags)
+def test_solve_unbounded(use_indirect, gpu):
   K = {
       'f': 10,
       'l': 15,
@@ -77,7 +85,3 @@ def solve_unbounded(use_indirect, gpu):
   data = tools.gen_unbounded(K, n=m // 3)
   params = {'normalize': True, 'scale': 0.5, 'cg_rate': 2}
   sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
-
-
-if __name__ == '__main__':
-  main()

--- a/test/test_solve_random_cone_prob.py
+++ b/test/test_solve_random_cone_prob.py
@@ -40,7 +40,7 @@ K = {
     'p': [-0.25, 0.5, 0.75, -0.33]
 }
 m = tools.get_scs_cone_dims(K)
-params = {'normalize': True, 'scale': 5, 'cg_rate': 2}
+params = {'normalize': True, 'scale': 5, 'cg_rate': 2, 'verbose': False}
 
 @pytest.mark.parametrize("use_indirect,gpu", flags)
 def test_solve_feasible(use_indirect, gpu):


### PR DESCRIPTION
While trying to verify that the GPU builds from https://github.com/conda-forge/scs-feedstock/pull/21 are working as intended (cf. this [comment](https://github.com/bodono/scs-python/issues/31#issuecomment-836808762)), I ran into a couple of problems;

The test suite is super noisy, it doesn't run with pytest (and nose is completely [dead](https://github.com/nose-devs/nose/)), and I couldn't tell if which flags had been picked up in `solve_random_cone_prob.py`.

I decided to refactor the test suite to be able to run with pytest, do some minimal parametrization (though much more could be done with those loops), turn `solve_random_cone_prob.py`. On the way, I fixed some (but not all) warnings, the remaining ones are:

<details>
<summary>Remaining warnings</summary>

```
================================================== warnings summary ===================================================
test/test_scs_python_linsys.py::test_python_linsys
  C:\Users\Axel\.conda\envs\test\lib\site-packages\scipy\sparse\linalg\dsolve\linsolve.py:318: SparseEfficiencyWarning: splu requires CSC matrix format
    warn('splu requires CSC matrix format', SparseEfficiencyWarning)

test/test_scs_python_linsys.py::test_python_linsys
  C:\Users\Axel\Dev\conda-forge\upstreams\scs-python\test\test_scs_python_linsys.py:102: RuntimeWarning: Mean of empty slice.
    D[start:start+delta] = D[start:start+delta].mean()

test/test_scs_python_linsys.py::test_python_linsys
  C:\Users\Axel\.conda\envs\test\lib\site-packages\numpy\core\_methods.py:188: RuntimeWarning: invalid value encountered in double_scalars
    ret = ret.dtype.type(ret / rcount)
```

</details>

It also gave me a somewhat unclear answer whether the GPU builds work; the tests pass (though it should be said that currently, `test_solve_random_cone_prob.py` just tests whether the solver runs through, and not the results it produces), but the following (truncated) log is produced:

<details>
<summary>GPU warnings/errors</summary>

```
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu\gpu.c:12:scs__accum_by_atrans_gpu
 ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu/indirect\private.c:270:scs_init_lin_sys_work
ERROR_CUDA: an illegal memory access was encountered
scs/linsys/gpu/indirect\private.c:270:scs_init_lin_sys_work
ERROR_CUDA: an illegal memory access was encountered
```

</details>

I also adapted the ~4 year old https://github.com/bodono/scs-python/blob/master/test/scs_benchmarks.ipynb to be runnable again, but ran into https://github.com/cvxpy/cvxpy/issues/1369 & https://github.com/cvxpy/cvxpy/issues/1370.

The changes in total are quite a few, I'm happy to split this into smaller PRs if desired; the commits are "designed" to be reviewable independently though, and should be quite manageable.