### PR TITLE
use flexible numpy version range at build time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = [
-    "numpy==1.17; python_version=='3.5'",
-    "numpy==1.17; python_version=='3.6'",
-    "numpy==1.17; python_version=='3.7'",
-    "numpy==1.17; python_version=='3.8'",
-    "numpy==1.19; python_version=='3.9'",
+    "numpy>=1.17,<1.18; python_version=='3.5'",
+    "numpy>=1.17,<1.18; python_version=='3.6'",
+    "numpy>=1.17,<1.18; python_version=='3.7'",
+    "numpy>=1.17,<1.18; python_version=='3.8'",
+    "numpy>=1.19,<1.20; python_version=='3.9'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
all that matters is the first minor version (e.g. 1.19.0 vs. 1.19.5 is no difference from abi interface perspective), so use a flexible version so that pip can choose to use the latest possible version. This speeds up builds for 3.9 as pre-built numpy wheel exists for 1.19.5 but not 1.19.0.