### PR TITLE
Pardiso mkl

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,4 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 
 [bumpversion:file:setup.py]
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Test
         run: |
-          python setup.py install
+          python setup.py install --scs --mkl
           pytest
           rm -rf build/
       - name: Build and test windows wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
           echo "SINGLE_ACTION_CONFIG=$( [[ $PYTHON_VERSION == 3.8 && $RUNNER_OS == 'macOS' ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
-          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV        
+          echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Build wheels
         if: ${{env.DEPLOY == 'True'}}
@@ -102,8 +102,8 @@ jobs:
           CIBW_BUILD: "cp3${{env.PYTHON_SUBVERSION}}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_BEFORE_ALL_LINUX: yum install -y openblas-devel
-          CIBW_BEFORE_ALL_MACOS: > 
-            brew install openblas && 
+          CIBW_BEFORE_ALL_MACOS: >
+            brew install openblas &&
             cp -r /usr/local/opt/openblas/lib/* /usr/local/lib &&
             cp /usr/local/opt/openblas/include/* /usr/local/include
           CIBW_ENVIRONMENT_MACOS: CFLAGS='-Wno-error=implicit-function-declaration'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
           fi
       - name: Test
         run: |
-          python setup.py install --scs --mkl
-          pytest
+          python setup.py install
+          pytest --ignore=test/test_solve_random_cone_prob_mkl.py
           rm -rf build/
       - name: Build and test windows wheels
         if: ${{env.DEPLOY == 'True' && startsWith(matrix.os, 'windows')}}
@@ -56,8 +56,8 @@ jobs:
           python setup.py bdist_wheel
           python -m pip install delvewheel
           delvewheel repair dist/*whl
-          pip install wheelhouse/*whl --force-reinstal
-          pytest
+          pip install wheelhouse/*whl --force-reinstall
+          pytest --ignore=test/test_solve_random_cone_prob_mkl.py
       - name: Upload artifacts to github
         if: ${{env.DEPLOY == 'True' && startsWith(matrix.os, 'windows')}}
         uses: actions/upload-artifact@v1
@@ -109,7 +109,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: CFLAGS='-Wno-error=implicit-function-declaration'
           CIBW_BUILD_VERBOSITY: 3
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {package}
+          CIBW_TEST_COMMAND: pytest {package} --ignore=test/test_solve_random_cone_prob_mkl.py
         uses: joerick/cibuildwheel@v2.3.1
 
       - name: Build source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test
         run: |
           python setup.py install
-          pytest --ignore=test/test_solve_random_cone_prob_mkl.py
+          pytest
           rm -rf build/
       - name: Build and test windows wheels
         if: ${{env.DEPLOY == 'True' && startsWith(matrix.os, 'windows')}}
@@ -57,7 +57,7 @@ jobs:
           python -m pip install delvewheel
           delvewheel repair dist/*whl
           pip install wheelhouse/*whl --force-reinstall
-          pytest --ignore=test/test_solve_random_cone_prob_mkl.py
+          pytest
       - name: Upload artifacts to github
         if: ${{env.DEPLOY == 'True' && startsWith(matrix.os, 'windows')}}
         uses: actions/upload-artifact@v1
@@ -109,7 +109,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: CFLAGS='-Wno-error=implicit-function-declaration'
           CIBW_BUILD_VERBOSITY: 3
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {package} --ignore=test/test_solve_random_cone_prob_mkl.py
+          CIBW_TEST_COMMAND: pytest {package}
         uses: joerick/cibuildwheel@v2.3.1
 
       - name: Build source

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-10.15, windows-2022 ]
+        # Windows not reporting MKL location correctly
+        os: [ ubuntu-18.04, macos-10.15 ] # windows-2022
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10" ]
 
     env:
@@ -36,7 +37,7 @@ jobs:
           channels: conda-forge,anaconda
       - name: Install dependencies
         run: |
-          conda install mkl scipy numpy pytest libblas=*=*mkl
+          conda install mkl scipy numpy pytest
       - name: Test
         run: |
           python setup.py install --scs --mkl

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -36,11 +36,7 @@ jobs:
           channels: conda-forge,anaconda
       - name: Install dependencies
         run: |
-          if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]] || [[ "$PYTHON_VERSION" == "3.9" ]]; then
-            conda install mkl scipy=1.5 numpy=1.19 pytest libblas=*=*mkl
-          elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
-            conda install mkl scipy=1.7 numpy=1.21 pytest libblas=*=*mkl
-          fi
+          conda install mkl scipy numpy pytest libblas=*=*mkl
       - name: Test
         run: |
           python setup.py install --scs --mkl

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -1,0 +1,48 @@
+name: build_mkl
+
+on: [push, pull_request]
+
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
+  build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macos-10.15, windows-2022 ]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10" ]
+
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge,anaconda
+      - name: Install dependencies
+        run: |
+          if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]] || [[ "$PYTHON_VERSION" == "3.9" ]]; then
+            conda install scipy=1.5 numpy=1.19 pytest mkl
+          elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
+            conda install scipy=1.7 numpy=1.21 pytest mkl
+          fi
+      - name: Test
+        run: |
+          python setup.py install --scs --mkl
+          pytest
+          rm -rf build/

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "$PYTHON_VERSION" == "3.6" ]] || [[ "$PYTHON_VERSION" == "3.7" ]] || [[ "$PYTHON_VERSION" == "3.8" ]] || [[ "$PYTHON_VERSION" == "3.9" ]]; then
-            conda install scipy=1.5 numpy=1.19 pytest mkl
+            conda install mkl scipy=1.5 numpy=1.19 pytest libblas=*=*mkl
           elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
-            conda install scipy=1.7 numpy=1.21 pytest mkl
+            conda install mkl scipy=1.7 numpy=1.21 pytest libblas=*=*mkl
           fi
       - name: Test
         run: |

--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,7 @@ def install_scs(**kwargs):
     if args.mkl:
         # TODO: This heuristic attempts to determine if MKL is installed.
         # Replace with something better.
+        blas_info, lapack_info = get_infos()
         blibs = blas_info["libraries"] + lapack_info["libraries"]
         if not any("mkl" in s for s in blibs):
             print(
@@ -250,11 +251,12 @@ def install_scs(**kwargs):
                 "an error please let us know by opening GitHub issue."
             )
         else:
+            # MKL should be included in the libraries already:
             _scs_mkl = Extension(
                 name="_scs_mkl",
                 sources=sources + glob("scs/linsys/mkl/direct/*.c"),
                 depends=glob("src/*.h"),
-                define_macros=list(define_macros),
+                define_macros=list(define_macros) + [("PY_MKL", None)],
                 include_dirs=include_dirs + ["scs/linsys/mkl/direct/"],
                 libraries=list(libraries),
                 extra_compile_args=list(extra_compile_args),
@@ -278,12 +280,12 @@ def install_scs(**kwargs):
         zip_safe=False,
         # TODO: update this:
         long_description=(
-            "Solves convex cone programs via operator splitting. "
+            "Solves convex quadratic cone programs via operator splitting. "
             "Can solve: linear programs (LPs), second-order cone "
             "programs (SOCPs), semidefinite programs (SDPs), "
             "exponential cone programs (ECPs), and power cone "
             "programs (PCPs), or problems with any combination of "
-            "those cones. See http://github.com/cvxgrp/scs for "
+            "those cones. See https://www.cvxgrp.org/scs/ for "
             "more details."
         ),
     )

--- a/setup.py
+++ b/setup.py
@@ -245,8 +245,9 @@ def install_scs(**kwargs):
         # TODO: This heuristic attempts to determine if MKL is installed.
         # Replace with something better.
         blas_info, lapack_info = get_infos()
-        blibs = blas_info["libraries"] + lapack_info["libraries"]
-        if not any("mkl" in s for s in blibs):
+        if "libraries" in blas_info and "libraries" in lapack_info:
+            blibs = blas_info["libraries"] + lapack_info["libraries"]
+        if not any("mkl" in s for s in (blibs or [])):
             print(
                 "MKL not found in blas / lapack info dicts, skipping SCS-MKL "
                 "install. Please install MKL and retry. If you think this is "

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ parser.add_argument(
     dest="mkl",
     action="store_true",
     default=False,
-    help="Also compile the MKL version of SCS (this option will be removed soon)",
+    help="Also compile the MKL version of SCS. MKL must be installed for this "
+    "to succeed. This option will be removed soon after which we shall "
+    "install the MKL version by default if MKL is available.",
 )
 parser.add_argument(
     "--float",

--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ def install_scs(**kwargs):
 
     setup(
         name="scs",
-        version="3.2.0",
+        version="3.2.1",
         author="Brendan O'Donoghue",
         author_email="bodonoghue85@gmail.com",
         url="http://github.com/cvxgrp/scs",

--- a/setup.py
+++ b/setup.py
@@ -244,26 +244,26 @@ def install_scs(**kwargs):
     if args.mkl:
         # TODO: This heuristic attempts to determine if MKL is installed.
         # Replace with something better.
-        blas_info, lapack_info = get_infos()
-        blibs = blas_info["libraries"] + lapack_info["libraries"]
-        if not any("mkl" in s for s in blibs):
-            print(
-                "MKL not found in blas / lapack info dicts, skipping SCS-MKL "
-                "install. Please install MKL and retry. If you think this is "
-                "an error please let us know by opening GitHub issue."
-            )
-        else:
-            # MKL should be included in the libraries already:
-            _scs_mkl = Extension(
-                name="_scs_mkl",
-                sources=sources + glob("scs/linsys/mkl/direct/*.c"),
-                depends=glob("src/*.h"),
-                define_macros=list(define_macros) + [("PY_MKL", None)],
-                include_dirs=include_dirs + ["scs/linsys/mkl/direct/"],
-                libraries=list(libraries),
-                extra_compile_args=list(extra_compile_args),
-            )
-            ext_modules += [_scs_mkl]
+        # blas_info, lapack_info = get_infos()
+        # blibs = blas_info["libraries"] + lapack_info["libraries"]
+        # if not any("mkl" in s for s in blibs):
+        #     print(
+        #         "MKL not found in blas / lapack info dicts, skipping SCS-MKL "
+        #         "install. Please install MKL and retry. If you think this is "
+        #         "an error please let us know by opening GitHub issue."
+        #     )
+        # else:
+        # MKL should be included in the libraries already:
+        _scs_mkl = Extension(
+            name="_scs_mkl",
+            sources=sources + glob("scs/linsys/mkl/direct/*.c"),
+            depends=glob("src/*.h"),
+            define_macros=list(define_macros) + [("PY_MKL", None)],
+            include_dirs=include_dirs + ["scs/linsys/mkl/direct/"],
+            libraries=list(libraries),
+            extra_compile_args=list(extra_compile_args),
+        )
+        ext_modules += [_scs_mkl]
 
     setup(
         name="scs",

--- a/setup.py
+++ b/setup.py
@@ -244,26 +244,26 @@ def install_scs(**kwargs):
     if args.mkl:
         # TODO: This heuristic attempts to determine if MKL is installed.
         # Replace with something better.
-        # blas_info, lapack_info = get_infos()
-        # blibs = blas_info["libraries"] + lapack_info["libraries"]
-        # if not any("mkl" in s for s in blibs):
-        #     print(
-        #         "MKL not found in blas / lapack info dicts, skipping SCS-MKL "
-        #         "install. Please install MKL and retry. If you think this is "
-        #         "an error please let us know by opening GitHub issue."
-        #     )
-        # else:
-        # MKL should be included in the libraries already:
-        _scs_mkl = Extension(
-            name="_scs_mkl",
-            sources=sources + glob("scs/linsys/mkl/direct/*.c"),
-            depends=glob("src/*.h"),
-            define_macros=list(define_macros) + [("PY_MKL", None)],
-            include_dirs=include_dirs + ["scs/linsys/mkl/direct/"],
-            libraries=list(libraries),
-            extra_compile_args=list(extra_compile_args),
-        )
-        ext_modules += [_scs_mkl]
+        blas_info, lapack_info = get_infos()
+        blibs = blas_info["libraries"] + lapack_info["libraries"]
+        if not any("mkl" in s for s in blibs):
+            print(
+                "MKL not found in blas / lapack info dicts, skipping SCS-MKL "
+                "install. Please install MKL and retry. If you think this is "
+                "an error please let us know by opening GitHub issue."
+            )
+        else:
+            # MKL should be included in the libraries already:
+            _scs_mkl = Extension(
+                name="_scs_mkl",
+                sources=sources + glob("scs/linsys/mkl/direct/*.c"),
+                depends=glob("src/*.h"),
+                define_macros=list(define_macros) + [("PY_MKL", None)],
+                include_dirs=include_dirs + ["scs/linsys/mkl/direct/"],
+                libraries=list(libraries),
+                extra_compile_args=list(extra_compile_args),
+            )
+            ext_modules += [_scs_mkl]
 
     setup(
         name="scs",

--- a/setup.py
+++ b/setup.py
@@ -105,11 +105,13 @@ def get_infos():
     blas_info = get_info("blas_opt")
     if not blas_info:
         blas_info = get_info("blas")
+    print("Blas info:")
     print(blas_info)
 
     lapack_info = get_info("lapack_opt")
     if not lapack_info:
         lapack_info = get_info("lapack")
+    print("Lapack info:")
     print(lapack_info)
 
     return blas_info, lapack_info

--- a/setup.py
+++ b/setup.py
@@ -184,14 +184,14 @@ def install_scs(**kwargs):
     _scs_direct = Extension(
         name="_scs_direct",
         sources=sources
-        + glob("scs/linsys/cpu/direct/*.c")
+        + glob("scs/linsys/mkl/direct/*.c")
         + glob("scs/linsys/external/amd/*.c")
         + glob("scs/linsys/external/qdldl/*.c"),
         depends=glob("src/*.h"),
         define_macros=list(define_macros),
         include_dirs=include_dirs
         + [
-            "scs/linsys/cpu/direct/",
+            "scs/linsys/mkl/direct/",
             "scs/linsys/external/amd",
             "scs/linsys/external/dqlql",
         ],
@@ -201,16 +201,17 @@ def install_scs(**kwargs):
 
     _scs_indirect = Extension(
         name="_scs_indirect",
-        sources=sources + glob("scs/linsys/cpu/indirect/*.c"),
+        sources=sources + glob("scs/linsys/mkl/indirect/*.c"),
         depends=glob("src/*.h"),
         define_macros=list(define_macros)
         + [("PY_INDIRECT", None), ("INDIRECT", 1)],
-        include_dirs=include_dirs + ["scs/linsys/cpu/indirect/"],
+        include_dirs=include_dirs + ["scs/linsys/mkl/indirect/"],
         libraries=list(libraries),
         extra_compile_args=list(extra_compile_args),
     )
 
-    ext_modules = [_scs_direct, _scs_indirect]
+    #ext_modules = [_scs_direct, _scs_indirect]
+    ext_modules = [_scs_direct]
 
     if args.gpu:
         library_dirs = []

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -34,10 +34,20 @@ def _select_scs_module(stgs):
 
         return _scs_gpu
 
+    if stgs.pop("mkl", False):  # False by default
+        if stgs.pop("use_indirect", False):
+            raise NotImplementedError(
+                "MKL indirect solver not yet available, pass `use_indirect=False`."
+            )
+        import _scs_mkl
+
+        return _scs_mkl
+
     if stgs.pop("use_indirect", _USE_INDIRECT_DEFAULT):
         import _scs_indirect
 
         return _scs_indirect
+
     return _scs_direct
 
 

--- a/src/scsmodule.h
+++ b/src/scsmodule.h
@@ -47,6 +47,8 @@ static PyObject *moduleinit(void) {
   m = Py_InitModule("_scs_indirect", scs_module_methods);
 #elif defined PY_GPU
   m = Py_InitModule("_scs_gpu", scs_module_methods);
+#elif defined PY_MKL
+  m = Py_InitModule("_scs_mkl", scs_module_methods);
 #else
   m = Py_InitModule("_scs_direct", scs_module_methods);
 #endif
@@ -75,6 +77,8 @@ PyMODINIT_FUNC
 PyInit__scs_indirect(void)
 #elif defined PY_GPU
 PyInit__scs_gpu(void)
+#elif defined PY_MKL
+PyInit__scs_mkl(void)
 #else
 PyInit__scs_direct(void)
 #endif
@@ -88,6 +92,8 @@ PyMODINIT_FUNC
 init_scs_indirect(void)
 #elif defined PY_GPU
 init_scs_gpu(void)
+#elif defined PY_MKL
+init_scs_mkl(void)
 #else
 init_scs_direct(void)
 #endif

--- a/test/test_solve_random_cone_prob_mkl.py
+++ b/test/test_solve_random_cone_prob_mkl.py
@@ -1,0 +1,76 @@
+from __future__ import print_function, division
+import scs
+import numpy as np
+from scipy import sparse
+import gen_random_cone_prob as tools
+
+#############################################
+#  Uses scs to solve a random cone problem  #
+#############################################
+
+
+def import_error(msg):
+    print()
+    print("## IMPORT ERROR:" + msg)
+    print()
+
+
+try:
+    import pytest
+except ImportError:
+    import_error("Please install pytest to run tests.")
+    raise
+
+np.random.seed(1)
+
+# cone:
+K = {
+    "f": 10,
+    "l": 15,
+    "q": [5, 10, 0, 1],
+    "s": [3, 4, 0, 0, 1, 10],
+    "ep": 10,
+    "ed": 10,
+    "p": [-0.25, 0.5, 0.75, -0.33],
+}
+m = tools.get_scs_cone_dims(K)
+params = {"verbose": True, "eps_abs": 1e-5, "eps_rel": 1e-5, "eps_infeas": 1e-5}
+
+
+def test_solve_feasible():
+    data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
+
+    sol = scs.solve(data, K, mkl=True, **params)
+    x = sol["x"]
+    y = sol["y"]
+    s = sol["s"]
+    np.testing.assert_almost_equal(np.dot(data["c"], x), p_star, decimal=3)
+    np.testing.assert_almost_equal(np.dot(data["c"], x), p_star, decimal=3)
+    np.testing.assert_array_less(
+        np.linalg.norm(data["A"] @ x - data["b"] + s), 1e-3
+    )
+    np.testing.assert_array_less(
+        np.linalg.norm(data["A"].T @ y + data["c"]), 1e-3
+    )
+    np.testing.assert_almost_equal(s.T @ y, 0.0)
+    np.testing.assert_almost_equal(s, tools.proj_cone(s, K), decimal=4)
+    np.testing.assert_almost_equal(y, tools.proj_dual_cone(y, K), decimal=4)
+
+
+def test_solve_infeasible():
+    data = tools.gen_infeasible(K, n=m // 2)
+    sol = scs.solve(data, K, mkl=True, **params)
+    y = sol["y"]
+    np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
+    np.testing.assert_array_less(data["b"].T @ y, -0.1)
+    np.testing.assert_almost_equal(y, tools.proj_dual_cone(y, K), decimal=4)
+
+
+def test_solve_unbounded():
+    data = tools.gen_unbounded(K, n=m // 2)
+    sol = scs.solve(data, K, mkl=True, **params)
+    x = sol["x"]
+    s = sol["s"]
+    np.testing.assert_array_less(np.linalg.norm(data["A"] @ x + s), 1e-3)
+    np.testing.assert_array_less(data["c"].T @ x, -0.1)
+    np.testing.assert_almost_equal(s, tools.proj_cone(s, K), decimal=4)


### PR DESCRIPTION
Update API to allow users to call the Pardiso MKL direct solver by passing in '--scs --mkl' when installing and then 'mkl=True' when calling. Add basic testing of this.