### PR TITLE
fix unable to install due to setuptools conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools",
+  "setuptools<65.6.0",
   "wheel",
   "oldest-supported-numpy",
 ]


### PR DESCRIPTION
setuptools == 65.6.0 remove `distutils.log.Log`, this leads to numpy issues see https://github.com/pypa/setuptools/issues/3693