### PR TITLE
meson build: fall back to dependancy if find_library fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,17 +7,29 @@ blas_deps = []
 if host_machine.system() == 'darwin'
   blas_deps = [dependency('Accelerate')]
 else
-  blas_deps = [dependency(['openblas', 'OpenBLAS'], static: get_option('link_blas_statically'), required : false)]
+  blas_deps = [cc.find_library('openblas', static: get_option('link_blas_statically'), required : false)]
+  if not blas_deps[0].found()
+    blas_deps = [dependency(['openblas', 'OpenBLAS'], static: get_option('link_blas_statically'), required : false)]
+  endif
 endif
 
 # try to find blas/cblas (e.g., Linux)
 if not blas_deps[0].found()
-    blas_deps = [dependency('blas', static: get_option('link_blas_statically'), required : false)]
-    lapack_dep = dependency('lapack', static: get_option('link_blas_statically'), required : false)
+    blas_deps = [cc.find_library('blas', static: get_option('link_blas_statically'), required : false)]
+    if not blas_deps[0].found()
+      blas_deps = [dependency('blas', static: get_option('link_blas_statically'), required : false)]
+    endif
+    lapack_dep = cc.find_library('lapack', static: get_option('link_blas_statically'), required : false)
+    if not lapack_dep.found()
+      lapack_dep = dependency('lapack', static: get_option('link_blas_statically'), required : false)
+    endif
     if lapack_dep.found()
         blas_deps += lapack_dep
     endif
-    cblas_dep = dependency('cblas', static: get_option('link_blas_statically'), required : false)
+    cblas_dep = cc.find_library('cblas', static: get_option('link_blas_statically'), required : false)
+    if not cblas_dep.found()
+      cblas_dep = dependency('cblas', static: get_option('link_blas_statically'), required : false)
+    endif
     if cblas_dep.found()
         blas_deps += cblas_dep
     endif

--- a/meson.build
+++ b/meson.build
@@ -7,17 +7,17 @@ blas_deps = []
 if host_machine.system() == 'darwin'
   blas_deps = [dependency('Accelerate')]
 else
-  blas_deps = [cc.find_library('openblas', static: get_option('link_blas_statically'), required : false)]
+  blas_deps = [dependency(['openblas', 'OpenBLAS'], static: get_option('link_blas_statically'), required : false)]
 endif
 
 # try to find blas/cblas (e.g., Linux)
 if not blas_deps[0].found()
-    blas_deps = [cc.find_library('blas', static: get_option('link_blas_statically'), required : false)]
-    lapack_dep = cc.find_library('lapack', static: get_option('link_blas_statically'), required : false)
+    blas_deps = [dependency('blas', static: get_option('link_blas_statically'), required : false)]
+    lapack_dep = dependency('lapack', static: get_option('link_blas_statically'), required : false)
     if lapack_dep.found()
         blas_deps += lapack_dep
     endif
-    cblas_dep = cc.find_library('cblas', static: get_option('link_blas_statically'), required : false)
+    cblas_dep = dependency('cblas', static: get_option('link_blas_statically'), required : false)
     if cblas_dep.found()
         blas_deps += cblas_dep
     endif


### PR DESCRIPTION
find_library only does a basic search for libs where dependency can use cmake and pkg-config. this is helpful on systems like nix where libraries are located over may uniquely named directories

https://github.com/NixOS/nixpkgs/pull/268178