### PR TITLE
Updates build-requires for NumPy 2.0 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python', 'oldest-supported-numpy']
+requires = [
+  "numpy >= 2.0.0; python_version > '3.8'",
+  "oldest-supported-numpy; python_version <= '3.8'",
+  "meson-python"
+]
 
 [project]
 name = 'scs'


### PR DESCRIPTION
Hi @bodono,

CVXPY installs are currently broken after the NumPy 2.0 release.
This PR makes sure NumPy >= 2.0 is used during the build (except Python 3.8, which does not have NumPy 2.0 wheels).
It is a backwards compatible change, as 2.0 builds work with prior NumPy versions at runtime, but not vice versa. 