### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.11" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -61,7 +61,7 @@ jobs:
         # macos-13 runners have intel chips. macos-14 and above
         # runners have Apple silicon chips.
         os: [ ubuntu-latest, macos-13, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13"]
         link_mkl: [true, false]
 
     env:
@@ -91,32 +91,22 @@ jobs:
           else
             BLAS_PKGS="blas-devel=*=*openblas"
           fi
-          if [[ "$PYTHON_VERSION" == "3.8" ]]; then
-            conda install scipy=1.5 numpy=1.19 pytest $BLAS_PKGS pkg-config 'setuptools<=60'
-          elif [[ "$PYTHON_VERSION" == "3.9" ]]; then
+          if [[ "$PYTHON_VERSION" == "3.9" ]]; then
             conda install scipy=1.5 numpy=1.19 pytest $BLAS_PKGS pkg-config
           elif [[ "$PYTHON_VERSION" == "3.10" ]]; then
             conda install scipy=1.7 numpy=1.21 pytest $BLAS_PKGS pkg-config
           elif [[ "$PYTHON_VERSION" == "3.11" ]]; then
             conda install scipy=1.9.3 numpy=1.23.4 pytest $BLAS_PKGS pkg-config
-          elif [[ "$PYTHON_VERSION" == "3.12" ]]; then
+          elif [[ "$PYTHON_VERSION" == "3.12" || "$PYTHON_VERSION" == "3.13" ]]; then
             conda install scipy numpy pytest $BLAS_PKGS pkg-config
           fi
       - name: Build
         run: |
-          if [[ "$PYTHON_VERSION" == "3.8" ]]; then
-            if [[ "$LINK_MKL" == "true" ]]; then
-              python legacy_setup.py install --scs --mkl
-            else
-              python legacy_setup.py install
-            fi
-          elif [[ "$PYTHON_VERSION" != "3.8" ]]; then
-            python -c "import numpy as np; print('NUMPY BLAS INFOS'); print(np.show_config())"
-            if [[ "$LINK_MKL" == "true" ]]; then
-              python -m pip install --verbose -Csetup-args=-Dlink_mkl=true .
-            else
-              python -m pip install --verbose .
-            fi
+          python -c "import numpy as np; print('NUMPY BLAS INFOS'); print(np.show_config())"
+          if [[ "$LINK_MKL" == "true" ]]; then
+            python -m pip install --verbose -Csetup-args=-Dlink_mkl=true .
+          else
+            python -m pip install --verbose .
           fi
       - name: Test
         run: |
@@ -148,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13"]
 
     env:
       RUNNER_OS: ${{ matrix.os }}
@@ -166,7 +156,7 @@ jobs:
         shell: bash
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "SINGLE_ACTION_CONFIG=$( [[ $PYTHON_VERSION == 3.8 && $RUNNER_OS == 'macOS' ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
+          echo "SINGLE_ACTION_CONFIG=False" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Build wheels
@@ -218,7 +208,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Set Additional Envs
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ 3.9, "3.10", "3.11" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           channels: conda-forge,anaconda
       - name: Install dependencies
         run: |
-          conda install scipy numpy pytest 'setuptools<=60'
+          conda install scipy numpy pytest setuptools
       - name: Test
         run: |
           python legacy_setup.py install --scs --openmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12",  ]
+        python-version: [ 3.9, "3.10", "3.11" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
           channels: conda-forge,anaconda
       - name: Install dependencies
         run: |
-          conda install scipy numpy pytest setuptools
+          conda install scipy numpy pytest setuptools<=60'
       - name: Test
         run: |
           python legacy_setup.py install --scs --openmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.11" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,6 @@ jobs:
         shell: bash
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "SINGLE_ACTION_CONFIG=False" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
 
       - name: Build wheels
@@ -170,12 +169,6 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}
         uses: joerick/cibuildwheel@v2.21.2
-
-      - name: Build source
-        if: ${{env.SINGLE_ACTION_CONFIG == 'True'}}
-        run: |
-          python -m pip install build
-          python -m build -Csetup-args="-Dlink_blas_statically=True" --outdir=wheelhouse
 
       - name: Upload artifacts to github
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           channels: conda-forge,anaconda
       - name: Install dependencies
         run: |
-          conda install scipy numpy pytest setuptools<=60'
+          conda install scipy numpy pytest 'setuptools<=60'
       - name: Test
         run: |
           python legacy_setup.py install --scs --openmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12",  ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-  "numpy >= 2.0.0; python_version > '3.8'",
-  "oldest-supported-numpy; python_version <= '3.8'",
+  "numpy >= 2.0.0; python_version > '3.9'",
+  "oldest-supported-numpy; python_version <= '3.9'",
   "meson-python"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-  "numpy >= 2.0.0; python_version > '3.9'",
-  "oldest-supported-numpy; python_version <= '3.9'",
+  "numpy >= 2.0.0; python_version > '3.8'",
+  "oldest-supported-numpy; python_version <= '3.8'",
   "meson-python"
 ]
 


### PR DESCRIPTION
Hi @bodono , I tried to mirror [your changes](https://github.com/bodono/scs-python/pull/86) from my previous request to support Python 3.12 / MacOS - now for the new release of Python 3.13!

I've also removed support for Python 3.8 since it's now [end-of-life](https://devguide.python.org/versions/).