### PR TITLE
MAINT: Cleanup with `pythoncapi-compat`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "scs_source"]
 	path = scs_source
 	url = https://github.com/cvxgrp/scs.git
+[submodule "scs/pythoncapi-compat"]
+	path = scs/pythoncapi-compat
+	url = https://github.com/python/pythoncapi-compat

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "scs"]
+[submodule "scs_source"]
 	path = scs_source
 	url = https://github.com/cvxgrp/scs.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,21 @@ version = "3.2.7"
 description = 'Splitting conic solver'
 readme = 'README.md'
 requires-python = '>=3.9'
+classifiers = [
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: C',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Operating System :: Unix',
+    'Operating System :: MacOS',
+]
 license = {file = 'LICENSE'}
 authors = [
   {name = "Brendan O'Donoghue", email = "bodonoghue85@gmail.com"}]

--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -1,3 +1,5 @@
+#include "pythoncapi-compat/pythoncapi_compat.h"
+
 #ifndef PY_SCSOBJECT_H
 #define PY_SCSOBJECT_H
 
@@ -398,7 +400,7 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
   d->A = A;
 
   /* set P if passed in */
-  if ((void *)Px != Py_None && (void *)Pi != Py_None && (void *)Pp != Py_None) {
+  if ((void *)!Py_IsNone(Px) && (void *)!Py_IsNone(Pi) && (void *)!Py_IsNone(Pp)) {
     if (!PyArray_ISFLOAT(Px) || PyArray_NDIM(Px) != 1) {
       free_py_scs_data(d, k, stgs, &ps);
       return finish_with_error("Px must be a numpy array of floats");
@@ -605,17 +607,17 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
 
   if (_warm_start) {
     /* If any of these of missing, we use the values in sol */
-    if ((void *)warm_x != Py_None) {
+    if ((void *)!Py_IsNone(warm_x)) {
       if (get_warm_start(self->sol->x, self->n, warm_x) < 0) {
         return none_with_error("Unable to parse x warm-start");
       }
     }
-    if ((void *)warm_y != Py_None) {
+    if ((void *)!Py_IsNone(warm_y)) {
       if (get_warm_start(self->sol->y, self->m, warm_y) < 0) {
         return none_with_error("Unable to parse y warm-start");
       }
     }
-    if ((void *)warm_s != Py_None) {
+    if ((void *)!Py_IsNone(warm_s)) {
       if (get_warm_start(self->sol->s, self->m, warm_s) < 0) {
         return none_with_error("Unable to parse s warm-start");
       }
@@ -727,7 +729,7 @@ PyObject *SCS_update(SCS *self, PyObject *args) {
     return none_with_error("Error parsing inputs");
   }
   /* set c */
-  if ((void *)c_new != Py_None) {
+  if ((void *)!Py_IsNone(c_new)) {
     if (!PyArray_ISFLOAT(c_new) || PyArray_NDIM(c_new) != 1) {
       return none_with_error(
           "c_new must be a dense numpy array with one dimension");
@@ -739,7 +741,7 @@ PyObject *SCS_update(SCS *self, PyObject *args) {
     c = (scs_float *)PyArray_DATA(c_new);
   }
   /* set b */
-  if ((void *)b_new != Py_None) {
+  if ((void *)!Py_IsNone(b_new)) {
     if (!PyArray_ISFLOAT(b_new) || PyArray_NDIM(b_new) != 1) {
       return none_with_error(
           "b must be a dense numpy array with one dimension");
@@ -776,7 +778,7 @@ static scs_int SCS_finish(SCS *self) {
   }
 
   /* Del python object */
-  PyObject_Del(self);
+  PyObject_Free(self);
 
   return 0;
 }


### PR DESCRIPTION
Split from #131, and is a prerequisite for it.
- Adds `pythoncapi-compat` ([repo](https://github.com/python/pythoncapi-compat))
 - Corrected the test path to ignore tests in `pythoncapi-compat`
- Updates `scsobject.h` with it 
- Renamed the `scs` submodule to match its path, i.e. `scs_source`
  - Also to be able to add `pythoncapi-compat` under `scs` 