### PR TITLE
Exposing cuDSS in the Python bindings

### DIFF
--- a/legacy_setup.py
+++ b/legacy_setup.py
@@ -34,6 +34,13 @@ parser.add_argument(
     "install the MKL version by default if MKL is available.",
 )
 parser.add_argument(
+    "--cudss",
+    dest="cudss",
+    action="store_true",
+    default=False,
+    help="Also compile the cuDSS version of SCS",
+)
+parser.add_argument(
     "--openmp",
     dest="openmp",
     action="store_true",
@@ -285,6 +292,21 @@ def install_scs(**kwargs):
             extra_link_args=list(extra_link_args),
         )
         ext_modules += [_scs_mkl]
+
+    if args.cudss:
+        # MKL should be included in the libraries already:
+        _scs_cudss = Extension(
+            name="_scs_cudss",
+            sources=sources + glob("scs_source/linsys/cudss/direct/*.c"),
+            depends=glob("scs/*.h"),
+            define_macros=list(define_macros) + [("PY_CUDSS", None)],
+            include_dirs=include_dirs + ["scs_source/linsys/cudss/direct/"],
+            libraries=list(libraries),
+            extra_compile_args=list(extra_compile_args),
+            extra_link_args=list(extra_link_args),
+        )
+        ext_modules += [_scs_cudss]
+
 
     setup(
         name="scs",

--- a/meson.build
+++ b/meson.build
@@ -232,6 +232,8 @@ endif
 
 if get_option('link_cudss')
   _deps += cuda_dep
+  cudss_dep = dependency('cudss', required: true)
+  _deps += cudss_dep
   py.extension_module(
     '_scs_cudss',
     'scs/scspy.c',

--- a/meson.build
+++ b/meson.build
@@ -105,7 +105,7 @@ if get_option('use_extraverbose')
   common_c_args += '-DVERBOSITY=999'
 endif
 
-is_gpu_build = get_option('use_gpu')
+is_gpu_build = get_option('use_gpu') or get_option('link_cudss')
 use_32bit_ints = get_option('int32')
 
 if is_gpu_build and not use_32bit_ints
@@ -121,9 +121,9 @@ if is_gpu_build and not cuda_dep.found()
   error('GPU build requested but CUDA toolkit was not found.')
 endif
 
-if is_gpu_build
+if is_gpu_build and get_option('use_gpu')
   gpu_c_args = common_c_args + ['-DPY_GPU=1', '-DINDIRECT=1']
-  deps += cuda_dep
+  _deps += cuda_dep
   if get_option('gpu_atrans')
     gpu_c_args += '-DGPU_TRANSPOSE_MAT=1'
   endif
@@ -136,7 +136,7 @@ if is_gpu_build
     fs.glob('scs_source/linsys/gpu/*.c'),
     fs.glob('scs_source/linsys/gpu/indirect/*.c'),
     c_args: gpu_c_args,
-    dependencies: deps,
+    dependencies: _deps,
     include_directories: [
       common_includes, 'scs_source/linsys/gpu/', 'scs_source/linsys/gpu/indirect'
     ],
@@ -229,5 +229,23 @@ if get_option('link_mkl')
     install: true,
   )
 endif
+
+if get_option('link_cudss')
+  _deps += cuda_dep
+  py.extension_module(
+    '_scs_cudss',
+    'scs/scspy.c',
+    'scs_source/linsys/cudss/direct/private.c',
+    common_linsys_sources,
+    scs_core_sources,
+    c_args: common_c_args + ['-DPY_CUDSS'],
+    include_directories: common_includes + ['scs_source/linsys/cudss/direct'],
+    dependencies: _deps,
+    install_dir: scs_dir,
+    install: true,
+  )
+endif
+
+
 
 py.install_sources('scs/py/__init__.py', subdir: 'scs')

--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,7 @@ if is_gpu_build and not cuda_dep.found()
   error('GPU build requested but CUDA toolkit was not found.')
 endif
 
-if is_gpu_build and get_option('use_gpu')
+if get_option('use_gpu')
   gpu_c_args = common_c_args + ['-DPY_GPU=1', '-DINDIRECT=1']
   _deps += cuda_dep
   if get_option('gpu_atrans')

--- a/meson.options
+++ b/meson.options
@@ -5,6 +5,8 @@ option('link_blas_statically', type: 'boolean',
        value: false, description: 'copy BLAS compiled object into SCS module(s)')
 option('link_mkl', type: 'boolean',
        value: false, description: 'link to mkl-rt library')
+option('link_cudss', type: 'boolean',
+       value: false, description: 'link to cuDSS library')
 option('use_openmp', type: 'boolean',
        value: false, description: 'Compile SCS with OpenMP parallelization enabled. This can make SCS faster, but requires a compiler with openMP support, the user must control how many threads OpenMP uses')
 option('sdist_mode', type: 'boolean', value: false,

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -44,6 +44,16 @@ def _select_scs_module(stgs):
 
         return _scs_mkl
 
+    if stgs.pop("cudss", False):  # False by default
+        if stgs.pop("use_indirect", False):
+            raise NotImplementedError(
+                "cuDSS indirect solver not yet available, pass `use_indirect=False`."
+            )
+        from scs import _scs_cudss
+
+        return _scs_cudss
+
+
     if stgs.pop("use_indirect", _USE_INDIRECT_DEFAULT):
         from scs import _scs_indirect
 

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -3,6 +3,7 @@ from warnings import warn
 from scipy import sparse
 from scs import _scs_direct
 
+PARTHS_VERSION = 1
 __version__ = _scs_direct.version()
 __sizeof_int__ = _scs_direct.sizeof_int()
 __sizeof_float__ = _scs_direct.sizeof_float()
@@ -26,13 +27,13 @@ SOLVED_INACCURATE = 2  # SCS best guess solved
 
 # Choose which SCS to import based on settings.
 def _select_scs_module(stgs):
+
     if stgs.pop("gpu", False):  # False by default
         if not stgs.pop("use_indirect", _USE_INDIRECT_DEFAULT):
             raise NotImplementedError(
-                "GPU direct solver not yet available, pass `use_indirect=True`."
-            )
+                "For the GPU direct solver, pass `use_indirect=False cudss=True`.")
         from scs import _scs_gpu
-
+        
         return _scs_gpu
 
     if stgs.pop("mkl", False):  # False by default

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -47,12 +47,11 @@ def _select_scs_module(stgs):
     if stgs.pop("cudss", False):  # False by default
         if stgs.pop("use_indirect", False):
             raise NotImplementedError(
-                "cuDSS indirect solver not yet available, pass `use_indirect=False`."
+                "cuDSS is a direct solver, pass `use_indirect=False`."
             )
         from scs import _scs_cudss
 
         return _scs_cudss
-
 
     if stgs.pop("use_indirect", _USE_INDIRECT_DEFAULT):
         from scs import _scs_indirect

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -3,7 +3,6 @@ from warnings import warn
 from scipy import sparse
 from scs import _scs_direct
 
-PARTHS_VERSION = 1
 __version__ = _scs_direct.version()
 __sizeof_int__ = _scs_direct.sizeof_int()
 __sizeof_float__ = _scs_direct.sizeof_float()

--- a/scs/scsmodule.h
+++ b/scs/scsmodule.h
@@ -49,6 +49,8 @@ static PyObject *moduleinit(void) {
   m = Py_InitModule("_scs_gpu", scs_module_methods);
 #elif defined PY_MKL
   m = Py_InitModule("_scs_mkl", scs_module_methods);
+#elif defined PY_CUDSS
+  m = Py_InitModule("_scs_cudss", scs_module_methods);
 #else
   m = Py_InitModule("_scs_direct", scs_module_methods);
 #endif
@@ -79,6 +81,8 @@ PyInit__scs_indirect(void)
 PyInit__scs_gpu(void)
 #elif defined PY_MKL
 PyInit__scs_mkl(void)
+#elif defined PY_CUDSS
+PyInit__scs_cudss(void)
 #else
 PyInit__scs_direct(void)
 #endif
@@ -94,6 +98,8 @@ init_scs_indirect(void)
 init_scs_gpu(void)
 #elif defined PY_MKL
 init_scs_mkl(void)
+#elif defined PY_CUDSS
+init_scs_cudss(void)
 #else
 init_scs_direct(void)
 #endif

--- a/test/test_solve_random_cone_prob_cudss.py
+++ b/test/test_solve_random_cone_prob_cudss.py
@@ -1,0 +1,82 @@
+from __future__ import print_function, division
+import scs
+import numpy as np
+from scipy import sparse
+import gen_random_cone_prob as tools
+
+#############################################
+#  Uses scs to solve a random cone problem  #
+#############################################
+
+
+def import_error(msg):
+    print()
+    print("## IMPORT ERROR:" + msg)
+    print()
+
+
+try:
+    import pytest
+except ImportError:
+    import_error("Please install pytest to run tests.")
+    raise
+
+np.random.seed(1)
+
+# cone:
+K = {
+    "z": 10,
+    "l": 15,
+    "q": [5, 10, 0, 1],
+    "s": [3, 4, 0, 0, 1, 10],
+    "ep": 10,
+    "ed": 10,
+    "p": [-0.25, 0.5, 0.75, -0.33],
+}
+m = tools.get_scs_cone_dims(K)
+params = {"verbose": True, "eps_abs": 1e-5, "eps_rel": 1e-5, "eps_infeas": 1e-5}
+
+
+try:
+    import _scs_cudss
+
+    def test_solve_feasible():
+        data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
+        solver = scs.SCS(data, K, cudss=True, **params)
+        sol = solver.solve()
+        x = sol["x"]
+        y = sol["y"]
+        s = sol["s"]
+        np.testing.assert_almost_equal(np.dot(data["c"], x), p_star, decimal=3)
+        np.testing.assert_almost_equal(np.dot(data["c"], x), p_star, decimal=3)
+        np.testing.assert_array_less(
+            np.linalg.norm(data["A"] @ x - data["b"] + s), 1e-3
+        )
+        np.testing.assert_array_less(
+            np.linalg.norm(data["A"].T @ y + data["c"]), 1e-3
+        )
+        np.testing.assert_almost_equal(s.T @ y, 0.0)
+        np.testing.assert_almost_equal(s, tools.proj_cone(s, K), decimal=4)
+        np.testing.assert_almost_equal(y, tools.proj_dual_cone(y, K), decimal=4)
+
+    def test_solve_infeasible():
+        data = tools.gen_infeasible(K, n=m // 2)
+        solver = scs.SCS(data, K, cudss=True, **params)
+        sol = solver.solve()
+        y = sol["y"]
+        np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
+        np.testing.assert_array_less(data["b"].T @ y, -0.1)
+        np.testing.assert_almost_equal(y, tools.proj_dual_cone(y, K), decimal=4)
+
+    def test_solve_unbounded():
+        data = tools.gen_unbounded(K, n=m // 2)
+        solver = scs.SCS(data, K, cudss=True, **params)
+        sol = solver.solve()
+        x = sol["x"]
+        s = sol["s"]
+        np.testing.assert_array_less(np.linalg.norm(data["A"] @ x + s), 1e-3)
+        np.testing.assert_array_less(data["c"].T @ x, -0.1)
+        np.testing.assert_almost_equal(s, tools.proj_cone(s, K), decimal=4)
+
+except ImportError:
+    import_error("Skipping cuDSS tests as SCS cuDSS is not installed.")

--- a/test/test_solve_random_cone_prob_cudss.py
+++ b/test/test_solve_random_cone_prob_cudss.py
@@ -38,7 +38,7 @@ params = {"verbose": True, "eps_abs": 1e-5, "eps_rel": 1e-5, "eps_infeas": 1e-5}
 
 
 try:
-    import _scs_cudss
+    from scs import _scs_cudss
 
     def test_solve_feasible():
         data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)

--- a/test/test_solve_random_cone_prob_mkl.py
+++ b/test/test_solve_random_cone_prob_mkl.py
@@ -38,7 +38,7 @@ params = {"verbose": True, "eps_abs": 1e-5, "eps_rel": 1e-5, "eps_infeas": 1e-5}
 
 
 try:
-    import _scs_mkl
+    from scs import _scs_mkl
 
     def test_solve_feasible():
         data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)


### PR DESCRIPTION
Here's my initial attempt at developing Python bindings for the new cuDSS solver. It compiles without error when I run

```bash
pip install --verbose -Csetup-args=-Dlink_cudss=true -Csetup-args=-Dint32=true .
```
but then `python -m _scs_cudss` fails, so I could use some help understanding what is wrong.

CC: @kalmarek