### PR TITLE
Add weekly CI cron job

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,121 @@
+name: Weekly tests
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:  # allow manual trigger
+
+jobs:
+
+  test_default:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install conda on Windows
+        if: runner.os == 'Windows'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: "latest"
+          channels: conda-forge, anaconda
+
+      - name: Install openblas from conda on Windows
+        if: runner.os == 'Windows'
+        run: conda install -y openblas pkgconfig
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        if: runner.os != 'Windows'
+        with:
+          cache: false
+          pixi-version: v0.46.0
+
+      - name: Add .pixi/envs/default to the $PATH
+        if: runner.os != 'Windows'
+        run: echo "$(pwd)/.pixi/envs/default/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
+        run: pixi add scipy numpy pip pytest meson meson-python openblas python==${{ matrix.python-version }}
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: pixi add scipy numpy pip pytest meson meson-python python==${{ matrix.python-version }}
+
+      - name: Build and test
+        run: |
+          pixi r python -m pip install -v . --no-build-isolation
+          pixi r pytest
+
+  test_mkl:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: false
+          pixi-version: v0.46.0
+
+      - name: Add .pixi/envs/default to the $PATH
+        run: echo "$(pwd)/.pixi/envs/default/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: pixi add blas-devel=*=*mkl pip scipy numpy pytest mkl mkl-devel pkg-config meson meson-python
+
+      - name: Build and test
+        run: |
+          pixi r python -m pip install -v . --no-build-isolation -Csetup-args=-Dlink_mkl=true
+          pixi r pytest
+
+  test_openmp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: false
+          pixi-version: v0.46.0
+
+      - name: Add .pixi/envs/default to the $PATH
+        run: echo "$(pwd)/.pixi/envs/default/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: pixi add scipy numpy pip pytest meson meson-python openblas
+
+      - name: Build and test
+        run: |
+          pixi r python -m pip install -v . --no-build-isolation -Csetup-args=-Duse_openmp=true
+          pixi r pytest


### PR DESCRIPTION
## Summary
- Adds a weekly CI workflow that runs every Monday at 06:00 UTC
- Tests the default build across ubuntu/macos/windows and Python 3.9–3.14
- Tests MKL and OpenMP builds on ubuntu with Python 3.12–3.13
- Includes `workflow_dispatch` for manual triggering

## Test plan
- [ ] Trigger manually via Actions tab to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)