### PR TITLE
Add weekly schedule and manual trigger to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
 on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
## Summary
- Add `schedule` trigger to existing `build.yml`: runs every Monday at 06:00 UTC
- Add `workflow_dispatch` for manual triggering from the Actions tab

## Test plan
- [ ] Trigger manually via Actions tab to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)