### PR TITLE
Add LinearSolver enum, remove boolean solver-selection flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ selects the best available solver for the platform:
 solver = scs.SCS(data, cone)
 
 # Explicitly select a solver
-solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.MKL)
-
-# String values also work
-solver = scs.SCS(data, cone, linear_solver="indirect")
+solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.QDLDL)
 ```
 
 Available values: `AUTO`, `QDLDL`, `INDIRECT`, `MKL`, `ACCELERATE`, `DENSE`,

--- a/README.md
+++ b/README.md
@@ -22,16 +22,29 @@ cd scs-python
 pip install .
 ```
 
-### Optional backends
+### Linear solver backends
 
-On macOS the Apple Accelerate backend is built automatically (no extra flags
-needed). Select it at runtime with `apple_ldl=True`:
+SCS supports several linear solver backends. The default is `AUTO`, which
+selects the best available solver for the platform:
+- **macOS**: Apple Accelerate if available, otherwise QDLDL
+- **Linux / Windows**: MKL Pardiso if available, otherwise QDLDL
 
 ```python
-solver = scs.SCS(data, cone, apple_ldl=True)
+# Auto-detect best backend (default)
+solver = scs.SCS(data, cone)
+
+# Explicitly select a solver
+solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.MKL)
+
+# String values also work
+solver = scs.SCS(data, cone, linear_solver="indirect")
 ```
 
-Other backends require build-time flags:
+Available values: `AUTO`, `QDLDL`, `INDIRECT`, `MKL`, `ACCELERATE`, `DENSE`,
+`GPU`, `CUDSS`.
+
+On macOS the Apple Accelerate backend is built automatically (no extra flags
+needed). Other backends require build-time flags:
 
 ```bash
 # MKL Pardiso direct solver

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.QDLDL)
 Available values: `AUTO`, `QDLDL`, `INDIRECT`, `MKL`, `ACCELERATE`, `DENSE`,
 `GPU`, `CUDSS`.
 
-On macOS the Apple Accelerate backend is built automatically (no extra flags
-needed). Other backends require build-time flags:
+The pre-built wheels (`pip install scs`) include MKL on x86_64 Linux and
+Windows, and Apple Accelerate on macOS. When installing from source, additional
+backends can be enabled with build-time flags:
 
 ```bash
 # MKL Pardiso direct solver

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import enum
+import sys
 import numpy as np
 from scipy import sparse
 from scs import _scs_direct
@@ -7,8 +9,6 @@ import warnings
 __version__ = _scs_direct.version()
 __sizeof_int__ = _scs_direct.sizeof_int()
 __sizeof_float__ = _scs_direct.sizeof_float()
-
-_USE_INDIRECT_DEFAULT = False
 
 
 # SCS return integers correspond to one of these flags:
@@ -25,63 +25,170 @@ SOLVED = 1  # problem solved to desired accuracy
 SOLVED_INACCURATE = 2  # SCS best guess solved
 
 
-# Choose which SCS to import based on settings.
-def _select_scs_module(stgs):
+class LinearSolver(enum.Enum):
+  """Linear system solver backend for SCS."""
+  AUTO = "auto"
+  QDLDL = "qdldl"
+  INDIRECT = "indirect"
+  MKL = "mkl"
+  ACCELERATE = "accelerate"
+  DENSE = "dense"
+  GPU = "gpu"
+  CUDSS = "cudss"
 
+
+# Old boolean flags that are now deprecated in favor of linear_solver=.
+_DEPRECATED_FLAGS = (
+    "use_indirect", "gpu", "mkl", "apple_ldl", "dense", "cudss", "qdldl",
+)
+
+
+def _map_legacy_flags(stgs):
+  """Convert deprecated boolean flags to a LinearSolver value.
+
+  Pops all legacy flags from stgs. Returns a LinearSolver or None if no
+  legacy flags were set (all False / absent).
+  """
   cudss = stgs.pop("cudss", False)
   gpu = stgs.pop("gpu", False)
   mkl = stgs.pop("mkl", False)
   apple_ldl = stgs.pop("apple_ldl", False)
   dense = stgs.pop("dense", False)
-  use_indirect = stgs.pop("use_indirect", _USE_INDIRECT_DEFAULT)
+  qdldl = stgs.pop("qdldl", False)
+  use_indirect = stgs.pop("use_indirect", False)
+
+  any_set = cudss or gpu or mkl or apple_ldl or dense or qdldl or use_indirect
+  if not any_set:
+    return None
+
+  warnings.warn(
+      "Passing boolean flags (gpu, mkl, apple_ldl, dense, cudss, qdldl, "
+      "use_indirect) to select the linear solver is deprecated. "
+      "Use linear_solver=scs.LinearSolver.<SOLVER> instead.",
+      DeprecationWarning,
+      stacklevel=4,
+  )
 
   if cudss:
     if not gpu or use_indirect:
       raise ValueError("To use cuDSS set gpu=True and use_indirect=False.")
+    return LinearSolver.CUDSS
 
   if gpu:
     if use_indirect:
-      from scs import _scs_gpu  # pylint: disable=g-import-not-at-top
-
-      return _scs_gpu
-    else:
-      from scs import _scs_cudss  # pylint: disable=g-import-not-at-top
-
-      return _scs_cudss
+      return LinearSolver.GPU
+    return LinearSolver.CUDSS
 
   if mkl:
     if use_indirect:
       raise NotImplementedError(
           "MKL indirect solver not yet available, pass `use_indirect=False`."
       )
-    from scs import _scs_mkl  # pylint: disable=g-import-not-at-top
-
-    return _scs_mkl
+    return LinearSolver.MKL
 
   if apple_ldl:
     if use_indirect:
       raise ValueError(
           "Accelerate solver is a direct method, pass `use_indirect=False`."
       )
-    from scs import _scs_accelerate  # pylint: disable=g-import-not-at-top
-
-    return _scs_accelerate
+    return LinearSolver.ACCELERATE
 
   if dense:
     if use_indirect:
       raise ValueError(
           "Dense solver is a direct method, pass `use_indirect=False`."
       )
-    from scs import _scs_dense  # pylint: disable=g-import-not-at-top
+    return LinearSolver.DENSE
 
-    return _scs_dense
+  if qdldl:
+    if use_indirect:
+      raise ValueError(
+          "QDLDL solver is a direct method, pass `use_indirect=False`."
+      )
+    return LinearSolver.QDLDL
 
   if use_indirect:
+    return LinearSolver.INDIRECT
+
+  return None
+
+
+def _resolve_auto():
+  """Auto-detect the best available direct solver for this platform."""
+  if sys.platform == "darwin":
+    try:
+      from scs import _scs_accelerate  # pylint: disable=g-import-not-at-top
+
+      return _scs_accelerate
+    except ImportError:
+      pass
+  else:
+    try:
+      from scs import _scs_mkl  # pylint: disable=g-import-not-at-top
+
+      return _scs_mkl
+    except ImportError:
+      pass
+  return _scs_direct
+
+
+def _select_scs_module(stgs):
+  """Choose which SCS C extension to import based on settings."""
+  linear_solver = stgs.pop("linear_solver", None)
+
+  # Check for deprecated boolean flags.
+  legacy = _map_legacy_flags(stgs)
+
+  if linear_solver is not None and legacy is not None:
+    raise ValueError(
+        "Cannot combine 'linear_solver' with deprecated boolean flags "
+        "(gpu, mkl, apple_ldl, dense, cudss, qdldl, use_indirect). "
+        "Use only 'linear_solver'."
+    )
+
+  if linear_solver is None:
+    linear_solver = legacy if legacy is not None else LinearSolver.AUTO
+
+  if isinstance(linear_solver, str):
+    linear_solver = LinearSolver(linear_solver)
+
+  if linear_solver == LinearSolver.AUTO:
+    return _resolve_auto()
+
+  if linear_solver == LinearSolver.QDLDL:
+    return _scs_direct
+
+  if linear_solver == LinearSolver.INDIRECT:
     from scs import _scs_indirect  # pylint: disable=g-import-not-at-top
 
     return _scs_indirect
 
-  return _scs_direct
+  if linear_solver == LinearSolver.MKL:
+    from scs import _scs_mkl  # pylint: disable=g-import-not-at-top
+
+    return _scs_mkl
+
+  if linear_solver == LinearSolver.ACCELERATE:
+    from scs import _scs_accelerate  # pylint: disable=g-import-not-at-top
+
+    return _scs_accelerate
+
+  if linear_solver == LinearSolver.DENSE:
+    from scs import _scs_dense  # pylint: disable=g-import-not-at-top
+
+    return _scs_dense
+
+  if linear_solver == LinearSolver.GPU:
+    from scs import _scs_gpu  # pylint: disable=g-import-not-at-top
+
+    return _scs_gpu
+
+  if linear_solver == LinearSolver.CUDSS:
+    from scs import _scs_cudss  # pylint: disable=g-import-not-at-top
+
+    return _scs_cudss
+
+  raise ValueError(f"Unknown linear_solver: {linear_solver!r}")
 
 
 def _has_lower_tri(P):

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -37,158 +37,44 @@ class LinearSolver(enum.Enum):
   CUDSS = "cudss"
 
 
-# Old boolean flags that are now deprecated in favor of linear_solver=.
-_DEPRECATED_FLAGS = (
-    "use_indirect", "gpu", "mkl", "apple_ldl", "dense", "cudss", "qdldl",
-)
-
-
-def _map_legacy_flags(stgs):
-  """Convert deprecated boolean flags to a LinearSolver value.
-
-  Pops all legacy flags from stgs. Returns a LinearSolver or None if no
-  legacy flags were set (all False / absent).
-  """
-  cudss = stgs.pop("cudss", False)
-  gpu = stgs.pop("gpu", False)
-  mkl = stgs.pop("mkl", False)
-  apple_ldl = stgs.pop("apple_ldl", False)
-  dense = stgs.pop("dense", False)
-  qdldl = stgs.pop("qdldl", False)
-  use_indirect = stgs.pop("use_indirect", False)
-
-  any_set = cudss or gpu or mkl or apple_ldl or dense or qdldl or use_indirect
-  if not any_set:
-    return None
-
-  warnings.warn(
-      "Passing boolean flags (gpu, mkl, apple_ldl, dense, cudss, qdldl, "
-      "use_indirect) to select the linear solver is deprecated. "
-      "Use linear_solver=scs.LinearSolver.<SOLVER> instead.",
-      DeprecationWarning,
-      stacklevel=4,
-  )
-
-  if cudss:
-    if not gpu or use_indirect:
-      raise ValueError("To use cuDSS set gpu=True and use_indirect=False.")
-    return LinearSolver.CUDSS
-
-  if gpu:
-    if use_indirect:
-      return LinearSolver.GPU
-    return LinearSolver.CUDSS
-
-  if mkl:
-    if use_indirect:
-      raise NotImplementedError(
-          "MKL indirect solver not yet available, pass `use_indirect=False`."
-      )
-    return LinearSolver.MKL
-
-  if apple_ldl:
-    if use_indirect:
-      raise ValueError(
-          "Accelerate solver is a direct method, pass `use_indirect=False`."
-      )
-    return LinearSolver.ACCELERATE
-
-  if dense:
-    if use_indirect:
-      raise ValueError(
-          "Dense solver is a direct method, pass `use_indirect=False`."
-      )
-    return LinearSolver.DENSE
-
-  if qdldl:
-    if use_indirect:
-      raise ValueError(
-          "QDLDL solver is a direct method, pass `use_indirect=False`."
-      )
-    return LinearSolver.QDLDL
-
-  if use_indirect:
-    return LinearSolver.INDIRECT
-
-  return None
+def _load_module(name):
+  from importlib import import_module
+  return import_module(f"scs.{name}")
 
 
 def _resolve_auto():
   """Auto-detect the best available direct solver for this platform."""
   if sys.platform == "darwin":
     try:
-      from scs import _scs_accelerate  # pylint: disable=g-import-not-at-top
-
-      return _scs_accelerate
+      return _load_module("_scs_accelerate")
     except ImportError:
       pass
   else:
     try:
-      from scs import _scs_mkl  # pylint: disable=g-import-not-at-top
-
-      return _scs_mkl
+      return _load_module("_scs_mkl")
     except ImportError:
       pass
   return _scs_direct
 
 
+_SOLVER_DISPATCH = {
+    LinearSolver.AUTO: _resolve_auto,
+    LinearSolver.QDLDL: lambda: _scs_direct,
+    LinearSolver.INDIRECT: lambda: _load_module("_scs_indirect"),
+    LinearSolver.MKL: lambda: _load_module("_scs_mkl"),
+    LinearSolver.ACCELERATE: lambda: _load_module("_scs_accelerate"),
+    LinearSolver.DENSE: lambda: _load_module("_scs_dense"),
+    LinearSolver.GPU: lambda: _load_module("_scs_gpu"),
+    LinearSolver.CUDSS: lambda: _load_module("_scs_cudss"),
+}
+
+
 def _select_scs_module(stgs):
   """Choose which SCS C extension to import based on settings."""
-  linear_solver = stgs.pop("linear_solver", None)
-
-  # Check for deprecated boolean flags.
-  legacy = _map_legacy_flags(stgs)
-
-  if linear_solver is not None and legacy is not None:
-    raise ValueError(
-        "Cannot combine 'linear_solver' with deprecated boolean flags "
-        "(gpu, mkl, apple_ldl, dense, cudss, qdldl, use_indirect). "
-        "Use only 'linear_solver'."
-    )
-
-  if linear_solver is None:
-    linear_solver = legacy if legacy is not None else LinearSolver.AUTO
-
+  linear_solver = stgs.pop("linear_solver", LinearSolver.AUTO)
   if isinstance(linear_solver, str):
     linear_solver = LinearSolver(linear_solver)
-
-  if linear_solver == LinearSolver.AUTO:
-    return _resolve_auto()
-
-  if linear_solver == LinearSolver.QDLDL:
-    return _scs_direct
-
-  if linear_solver == LinearSolver.INDIRECT:
-    from scs import _scs_indirect  # pylint: disable=g-import-not-at-top
-
-    return _scs_indirect
-
-  if linear_solver == LinearSolver.MKL:
-    from scs import _scs_mkl  # pylint: disable=g-import-not-at-top
-
-    return _scs_mkl
-
-  if linear_solver == LinearSolver.ACCELERATE:
-    from scs import _scs_accelerate  # pylint: disable=g-import-not-at-top
-
-    return _scs_accelerate
-
-  if linear_solver == LinearSolver.DENSE:
-    from scs import _scs_dense  # pylint: disable=g-import-not-at-top
-
-    return _scs_dense
-
-  if linear_solver == LinearSolver.GPU:
-    from scs import _scs_gpu  # pylint: disable=g-import-not-at-top
-
-    return _scs_gpu
-
-  if linear_solver == LinearSolver.CUDSS:
-    from scs import _scs_cudss  # pylint: disable=g-import-not-at-top
-
-    return _scs_cudss
-
-  raise ValueError(f"Unknown linear_solver: {linear_solver!r}")
+  return _SOLVER_DISPATCH[linear_solver]()
 
 
 def _has_lower_tri(P):

--- a/test/solve_random_cone_prob.py
+++ b/test/solve_random_cone_prob.py
@@ -9,7 +9,7 @@ import gen_random_cone_prob as tools
 
 
 def main():
-    solvers = [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
+    solvers = [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
     try:
         from scs import _scs_gpu
 

--- a/test/solve_random_cone_prob.py
+++ b/test/solve_random_cone_prob.py
@@ -9,22 +9,22 @@ import gen_random_cone_prob as tools
 
 
 def main():
-    flags = [(False, False), (True, False)]
+    solvers = [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
     try:
-        import _scs_gpu
+        from scs import _scs_gpu
 
-        flags += [(True, True)]
+        solvers.append(scs.LinearSolver.GPU)
     except ImportError:
         pass
 
-    for use_indirect, gpu in flags:
+    for linear_solver in solvers:
         np.random.seed(1)
-        solve_feasible(use_indirect, gpu)
-        solve_infeasible(use_indirect, gpu)
-        solve_unbounded(use_indirect, gpu)
+        solve_feasible(linear_solver)
+        solve_infeasible(linear_solver)
+        solve_unbounded(linear_solver)
 
 
-def solve_feasible(use_indirect, gpu):
+def solve_feasible(linear_solver):
     # cone:
     K = {
         "z": 10,
@@ -39,7 +39,7 @@ def solve_feasible(use_indirect, gpu):
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.01)
     params = {"normalize": True, "scale": 5}
 
-    sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    sol = scs.solve(data, K, linear_solver=linear_solver, **params)
     x = sol["x"]
     y = sol["y"]
     print("p*  = ", p_star)
@@ -47,7 +47,7 @@ def solve_feasible(use_indirect, gpu):
     print("dual error = ", (-np.dot(data["b"], y) - p_star) / p_star)
 
 
-def solve_infeasible(use_indirect, gpu):
+def solve_infeasible(linear_solver):
     K = {
         "z": 10,
         "l": 15,
@@ -60,10 +60,10 @@ def solve_infeasible(use_indirect, gpu):
     m = tools.get_scs_cone_dims(K)
     data = tools.gen_infeasible(K, n=m // 3)
     params = {"normalize": True, "scale": 0.5}
-    sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    sol = scs.solve(data, K, linear_solver=linear_solver, **params)
 
 
-def solve_unbounded(use_indirect, gpu):
+def solve_unbounded(linear_solver):
     K = {
         "z": 10,
         "l": 15,
@@ -76,7 +76,7 @@ def solve_unbounded(use_indirect, gpu):
     m = tools.get_scs_cone_dims(K)
     data = tools.gen_unbounded(K, n=m // 3)
     params = {"normalize": True, "scale": 0.5}
-    sol = scs.solve(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    sol = scs.solve(data, K, linear_solver=linear_solver, **params)
 
 
 if __name__ == "__main__":

--- a/test/test_mix_sd_csd_cone.py
+++ b/test/test_mix_sd_csd_cone.py
@@ -20,11 +20,11 @@ except ImportError:
     pass
 
 _solver_configs = [
-    {"use_indirect": False},
-    {"use_indirect": True},
+    {"linear_solver": scs.LinearSolver.QDLDL},
+    {"linear_solver": scs.LinearSolver.INDIRECT},
 ]
 if _dense_available:
-    _solver_configs.append({"dense": True})
+    _solver_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _solver_configs)

--- a/test/test_mix_sd_csd_cone.py
+++ b/test/test_mix_sd_csd_cone.py
@@ -20,6 +20,7 @@ except ImportError:
     pass
 
 _solver_configs = [
+    {"linear_solver": scs.LinearSolver.AUTO},
     {"linear_solver": scs.LinearSolver.QDLDL},
     {"linear_solver": scs.LinearSolver.INDIRECT},
 ]

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -43,6 +43,7 @@ FAIL = "failure"  # scs code for failure
 
 
 _solver_configs = [
+    scs.LinearSolver.AUTO,
     scs.LinearSolver.QDLDL,
     scs.LinearSolver.INDIRECT,
 ]
@@ -76,8 +77,10 @@ if platform.python_version_tuple() < ("3", "0", "0"):
     @pytest.mark.parametrize(
         "cone,linear_solver,expected",
         [
+            ({"q": [], "l": long(2)}, scs.LinearSolver.AUTO, 1),
             ({"q": [], "l": long(2)}, scs.LinearSolver.QDLDL, 1),
             ({"q": [], "l": long(2)}, scs.LinearSolver.INDIRECT, 1),
+            ({"q": [long(2)], "l": 0}, scs.LinearSolver.AUTO, 0.5),
             ({"q": [long(2)], "l": 0}, scs.LinearSolver.QDLDL, 0.5),
             ({"q": [long(2)], "l": 0}, scs.LinearSolver.INDIRECT, 0.5),
         ],

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -42,34 +42,30 @@ data = {"A": A, "b": b, "c": c}
 FAIL = "failure"  # scs code for failure
 
 
-_dense_available = False
+_solver_configs = [
+    scs.LinearSolver.QDLDL,
+    scs.LinearSolver.INDIRECT,
+]
 try:
     from scs import _scs_dense
-    _dense_available = True
+    _solver_configs.append(scs.LinearSolver.DENSE)
 except ImportError:
     pass
 
-_test_configs = [
-    (False, False),
-    (True, False),
-]
-if _dense_available:
-    _test_configs.append((False, True))
-
 
 @pytest.mark.parametrize(
-    "cone,use_indirect,dense,expected",
+    "cone,linear_solver,expected",
     [
-        (c, ui, d, e)
+        (c, ls, e)
         for c, e in [
             ({"q": [], "l": 2}, 1),
             ({"q": [2], "l": 0}, 0.5),
         ]
-        for ui, d in _test_configs
+        for ls in _solver_configs
     ],
 )
-def test_problems(cone, use_indirect, dense, expected):
-    solver = scs.SCS(data, cone=cone, use_indirect=use_indirect, dense=dense,
+def test_problems(cone, linear_solver, expected):
+    solver = scs.SCS(data, cone=cone, linear_solver=linear_solver,
                      verbose=False)
     sol = solver.solve()
     assert_almost_equal(sol["x"][0], expected, decimal=2)
@@ -78,17 +74,17 @@ def test_problems(cone, use_indirect, dense, expected):
 if platform.python_version_tuple() < ("3", "0", "0"):
 
     @pytest.mark.parametrize(
-        "cone,use_indirect,expected",
+        "cone,linear_solver,expected",
         [
-            ({"q": [], "l": long(2)}, False, 1),
-            ({"q": [], "l": long(2)}, True, 1),
-            ({"q": [long(2)], "l": 0}, False, 0.5),
-            ({"q": [long(2)], "l": 0}, True, 0.5),
+            ({"q": [], "l": long(2)}, scs.LinearSolver.QDLDL, 1),
+            ({"q": [], "l": long(2)}, scs.LinearSolver.INDIRECT, 1),
+            ({"q": [long(2)], "l": 0}, scs.LinearSolver.QDLDL, 0.5),
+            ({"q": [long(2)], "l": 0}, scs.LinearSolver.INDIRECT, 0.5),
         ],
     )
-    def test_problems_with_longs(cone, use_indirect, expected):
+    def test_problems_with_longs(cone, linear_solver, expected):
         sol = scs.solve(
-            data, cone=cone, use_indirect=use_indirect, verbose=False
+            data, cone=cone, linear_solver=linear_solver, verbose=False
         )
         assert_almost_equal(sol["x"][0], expected, decimal=2)
 

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -306,7 +306,7 @@ def test_solution_keys():
 # ===========================================================================
 
 
-@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
 def test_tight_tolerances(linear_solver):
     """Tighter eps should still produce a correct solution."""
     solver = scs.SCS(
@@ -321,7 +321,7 @@ def test_tight_tolerances(linear_solver):
     assert_almost_equal(sol["x"][0], 1.0, decimal=3)
 
 
-@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
 def test_loose_tolerances(linear_solver):
     """Very loose tolerances should still converge quickly."""
     solver = scs.SCS(
@@ -686,7 +686,7 @@ def _make_qp_data():
     return {"A": _A.copy(), "b": _b.copy(), "c": np.array([-1.0]), "P": P}
 
 
-@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
 def test_qp_with_settings(linear_solver):
     solver = scs.SCS(
         _make_qp_data(), _CONE,
@@ -873,7 +873,7 @@ def test_exp_cone_primal_known_solution():
     assert_almost_equal(sol["x"][0], np.e, decimal=4)
 
 
-@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
 def test_exp_cone_both_solvers(linear_solver):
     """Exp cone problem solved with both direct and indirect backends."""
     A_exp = sp.csc_matrix(np.array([
@@ -1236,7 +1236,7 @@ def test_sdp_2x2_known_solution():
     assert_almost_equal(sol["x"][0], -1.0, decimal=4)
 
 
-@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
 def test_sdp_both_solvers(linear_solver):
     """SDP solved with both direct and indirect backends."""
     sq2 = np.sqrt(2.0)
@@ -2873,3 +2873,125 @@ def test_linear_solver_default_is_auto():
     solver = scs.SCS(_make_data(), _CONE, verbose=False)
     sol = solver.solve()
     assert sol["info"]["status"] == "solved"
+
+
+def test_linear_solver_auto_explicit():
+    """Explicitly passing AUTO should solve correctly."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver=scs.LinearSolver.AUTO, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+    assert_almost_equal(sol["x"][0], 1.0, decimal=3)
+
+
+def test_linear_solver_auto_string():
+    """Passing 'auto' as a string should work."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver="auto", verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+# ===========================================================================
+# 92. AUTO fallback logic
+# ===========================================================================
+
+
+def test_resolve_auto_falls_back_to_qdldl():
+    """AUTO should fall back to QDLDL when platform-preferred module is missing."""
+    from unittest.mock import patch
+    from scs import _resolve_auto, _scs_direct
+
+    def fail_import(name):
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs._load_module", side_effect=fail_import):
+        module = _resolve_auto()
+    assert module is _scs_direct
+
+
+def test_resolve_auto_darwin_tries_accelerate():
+    """On macOS, AUTO should try _scs_accelerate first."""
+    from unittest.mock import patch, MagicMock
+    from scs import _resolve_auto
+
+    fake_accel = MagicMock()
+
+    def mock_load(name):
+        if name == "_scs_accelerate":
+            return fake_accel
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs.sys") as mock_sys:
+        mock_sys.platform = "darwin"
+        with patch("scs._load_module", side_effect=mock_load):
+            module = _resolve_auto()
+    assert module is fake_accel
+
+
+def test_resolve_auto_linux_tries_mkl():
+    """On Linux, AUTO should try _scs_mkl first."""
+    from unittest.mock import patch, MagicMock
+    from scs import _resolve_auto
+
+    fake_mkl = MagicMock()
+
+    def mock_load(name):
+        if name == "_scs_mkl":
+            return fake_mkl
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs.sys") as mock_sys:
+        mock_sys.platform = "linux"
+        with patch("scs._load_module", side_effect=mock_load):
+            module = _resolve_auto()
+    assert module is fake_mkl
+
+
+def test_resolve_auto_windows_tries_mkl():
+    """On Windows, AUTO should try _scs_mkl first."""
+    from unittest.mock import patch, MagicMock
+    from scs import _resolve_auto
+
+    fake_mkl = MagicMock()
+
+    def mock_load(name):
+        if name == "_scs_mkl":
+            return fake_mkl
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs.sys") as mock_sys:
+        mock_sys.platform = "win32"
+        with patch("scs._load_module", side_effect=mock_load):
+            module = _resolve_auto()
+    assert module is fake_mkl
+
+
+def test_resolve_auto_darwin_fallback_when_no_accelerate():
+    """On macOS, AUTO should fall back to QDLDL when Accelerate is missing."""
+    from unittest.mock import patch
+    from scs import _resolve_auto, _scs_direct
+
+    def fail_import(name):
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs.sys") as mock_sys:
+        mock_sys.platform = "darwin"
+        with patch("scs._load_module", side_effect=fail_import):
+            module = _resolve_auto()
+    assert module is _scs_direct
+
+
+def test_resolve_auto_linux_fallback_when_no_mkl():
+    """On Linux, AUTO should fall back to QDLDL when MKL is missing."""
+    from unittest.mock import patch
+    from scs import _resolve_auto, _scs_direct
+
+    def fail_import(name):
+        raise ImportError(f"mocked: {name}")
+
+    with patch("scs.sys") as mock_sys:
+        mock_sys.platform = "linux"
+        with patch("scs._load_module", side_effect=fail_import):
+            module = _resolve_auto()
+    assert module is _scs_direct

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -232,44 +232,19 @@ def test_P_full_symmetric_extracts_upper():
 # ===========================================================================
 
 
-def test_cudss_without_gpu_raises():
-    """Passing cudss=True without gpu=True should raise ValueError."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(ValueError, match="gpu=True"):
-            scs.SCS(_make_data(), _CONE, cudss=True, verbose=False)
+def test_invalid_linear_solver_string_raises():
+    """Passing an invalid string for linear_solver should raise ValueError."""
+    with pytest.raises(ValueError):
+        scs.SCS(_make_data(), _CONE, linear_solver="invalid", verbose=False)
 
 
-def test_mkl_with_indirect_raises():
-    """Passing mkl=True and use_indirect=True should raise NotImplementedError."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=True, verbose=False)
-            pytest.skip("_scs_mkl not built")
-        except NotImplementedError as exc:
-            assert "use_indirect=False" in str(exc)
-        except ImportError:
-            pytest.skip("_scs_mkl not built")
-
-
-def test_dense_with_indirect_raises():
-    """Passing dense=True and use_indirect=True should raise ValueError."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(ValueError, match="use_indirect=False"):
-            scs.SCS(_make_data(), _CONE, dense=True, use_indirect=True, verbose=False)
-
-
-def test_dense_direct_tries_import():
-    """dense=True, use_indirect=False should attempt to import _scs_dense."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, dense=True, use_indirect=False,
-                    verbose=False)
-        except ImportError:
-            pass  # Expected: _scs_dense not built
+def test_dense_tries_import():
+    """linear_solver=DENSE should attempt to import _scs_dense."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.DENSE, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_dense not built
 
 
 # ===========================================================================
@@ -331,12 +306,12 @@ def test_solution_keys():
 # ===========================================================================
 
 
-@pytest.mark.parametrize("use_indirect", [False, True])
-def test_tight_tolerances(use_indirect):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+def test_tight_tolerances(linear_solver):
     """Tighter eps should still produce a correct solution."""
     solver = scs.SCS(
         _make_data(), _CONE,
-        use_indirect=use_indirect,
+        linear_solver=linear_solver,
         eps_abs=1e-9,
         eps_rel=1e-9,
         verbose=False,
@@ -346,12 +321,12 @@ def test_tight_tolerances(use_indirect):
     assert_almost_equal(sol["x"][0], 1.0, decimal=3)
 
 
-@pytest.mark.parametrize("use_indirect", [False, True])
-def test_loose_tolerances(use_indirect):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+def test_loose_tolerances(linear_solver):
     """Very loose tolerances should still converge quickly."""
     solver = scs.SCS(
         _make_data(), _CONE,
-        use_indirect=use_indirect,
+        linear_solver=linear_solver,
         eps_abs=1e-2,
         eps_rel=1e-2,
         verbose=False,
@@ -679,7 +654,7 @@ def test_legacy_solve_partial_warmstart():
 def test_indirect_solver_with_tight_tolerances():
     solver = scs.SCS(
         _make_data(), _CONE,
-        use_indirect=True,
+        linear_solver=scs.LinearSolver.INDIRECT,
         eps_abs=1e-8,
         eps_rel=1e-8,
         verbose=False,
@@ -692,7 +667,7 @@ def test_indirect_solver_with_tight_tolerances():
 def test_indirect_solver_acceleration_off():
     solver = scs.SCS(
         _make_data(), _CONE,
-        use_indirect=True,
+        linear_solver=scs.LinearSolver.INDIRECT,
         acceleration_lookback=0,
         verbose=False,
     )
@@ -711,11 +686,11 @@ def _make_qp_data():
     return {"A": _A.copy(), "b": _b.copy(), "c": np.array([-1.0]), "P": P}
 
 
-@pytest.mark.parametrize("use_indirect", [False, True])
-def test_qp_with_settings(use_indirect):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+def test_qp_with_settings(linear_solver):
     solver = scs.SCS(
         _make_qp_data(), _CONE,
-        use_indirect=use_indirect,
+        linear_solver=linear_solver,
         eps_abs=1e-7,
         eps_rel=1e-7,
         verbose=False,
@@ -898,8 +873,8 @@ def test_exp_cone_primal_known_solution():
     assert_almost_equal(sol["x"][0], np.e, decimal=4)
 
 
-@pytest.mark.parametrize("use_indirect", [False, True])
-def test_exp_cone_both_solvers(use_indirect):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+def test_exp_cone_both_solvers(linear_solver):
     """Exp cone problem solved with both direct and indirect backends."""
     A_exp = sp.csc_matrix(np.array([
         [0.0,  1.0,  0.0],
@@ -915,7 +890,7 @@ def test_exp_cone_both_solvers(use_indirect):
     solver = scs.SCS(
         {"A": A_exp, "b": b_exp, "c": c_exp},
         cone_exp,
-        use_indirect=use_indirect,
+        linear_solver=linear_solver,
         verbose=False,
     )
     sol = solver.solve()
@@ -1261,8 +1236,8 @@ def test_sdp_2x2_known_solution():
     assert_almost_equal(sol["x"][0], -1.0, decimal=4)
 
 
-@pytest.mark.parametrize("use_indirect", [False, True])
-def test_sdp_both_solvers(use_indirect):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT])
+def test_sdp_both_solvers(linear_solver):
     """SDP solved with both direct and indirect backends."""
     sq2 = np.sqrt(2.0)
     A_sdp = sp.csc_matrix(np.array([[0.0], [-sq2], [0.0]]))
@@ -1273,7 +1248,7 @@ def test_sdp_both_solvers(use_indirect):
     solver = scs.SCS(
         {"A": A_sdp, "b": b_sdp, "c": c_sdp},
         cone_sdp,
-        use_indirect=use_indirect,
+        linear_solver=linear_solver,
         verbose=False,
     )
     sol = solver.solve()
@@ -1911,8 +1886,10 @@ def test_cs_cone_mixed_with_real_cones():
 def test_direct_indirect_same_answer_lp():
     """Direct and indirect solvers must agree on the LP optimal to 4 decimal places."""
     opts = dict(eps_abs=1e-9, eps_rel=1e-9, verbose=False)
-    sol_d = scs.SCS(_make_data(), _CONE, **opts).solve()
-    sol_i = scs.SCS(_make_data(), _CONE, use_indirect=True, **opts).solve()
+    sol_d = scs.SCS(_make_data(), _CONE,
+                    linear_solver=scs.LinearSolver.QDLDL, **opts).solve()
+    sol_i = scs.SCS(_make_data(), _CONE,
+                    linear_solver=scs.LinearSolver.INDIRECT, **opts).solve()
     assert sol_d["info"]["status"] in ("solved", "solved_inaccurate")
     assert sol_i["info"]["status"] in ("solved", "solved_inaccurate")
     assert_almost_equal(sol_d["x"][0], sol_i["x"][0], decimal=4)
@@ -1922,10 +1899,10 @@ def test_direct_indirect_same_answer_qp():
     """Direct and indirect solvers must agree on the QP optimal to 3 decimal places."""
     P = sp.csc_matrix(np.array([[2.0]]))
     opts = dict(eps_abs=1e-9, eps_rel=1e-9, verbose=False)
-    sol_d = scs.SCS({"A": _A, "b": _b, "c": _c, "P": P}, _CONE, **opts).solve()
-    sol_i = scs.SCS(
-        {"A": _A, "b": _b, "c": _c, "P": P}, _CONE, use_indirect=True, **opts
-    ).solve()
+    sol_d = scs.SCS({"A": _A, "b": _b, "c": _c, "P": P}, _CONE,
+                    linear_solver=scs.LinearSolver.QDLDL, **opts).solve()
+    sol_i = scs.SCS({"A": _A, "b": _b, "c": _c, "P": P}, _CONE,
+                    linear_solver=scs.LinearSolver.INDIRECT, **opts).solve()
     assert_almost_equal(sol_d["x"][0], sol_i["x"][0], decimal=3)
 
 
@@ -2219,69 +2196,38 @@ def test_negative_max_iters_raises():
 # ===========================================================================
 
 
-def test_cudss_true_gpu_true_indirect_true_raises():
-    """cudss=True, gpu=True, use_indirect=True should raise ValueError."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(ValueError, match="gpu=True"):
-            scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
-                    use_indirect=True, verbose=False)
+def test_cudss_tries_import():
+    """linear_solver=CUDSS should attempt to import _scs_cudss."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.CUDSS, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_cudss not built
 
 
-def test_cudss_true_gpu_true_indirect_false_tries_import():
-    """cudss=True, gpu=True, use_indirect=False should attempt to import
-    _scs_cudss (ImportError expected if not built)."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
-                    use_indirect=False, verbose=False)
-        except ImportError:
-            pass  # Expected: _scs_cudss not built
+def test_gpu_tries_import():
+    """linear_solver=GPU should attempt to import _scs_gpu."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.GPU, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_gpu not built
 
 
-def test_gpu_true_mkl_true_no_leak():
-    """gpu=True, mkl=True should NOT leak 'mkl' kwarg into the C extension.
-    The mkl flag must be popped before passing settings to C."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, gpu=True, mkl=True, verbose=False)
-        except ImportError:
-            pass  # Expected: _scs_gpu/_scs_cudss not built
-        # If mkl leaked through, the C extension would raise TypeError
-        # about unexpected kwarg. The ImportError (not TypeError) proves it
-        # was properly popped.
+def test_mkl_tries_import():
+    """linear_solver=MKL should attempt to import _scs_mkl."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.MKL, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_mkl not built
 
 
-def test_gpu_indirect_tries_import():
-    """gpu=True, use_indirect=True should attempt to import _scs_gpu."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, gpu=True, use_indirect=True,
-                    verbose=False)
-        except ImportError:
-            pass  # Expected: _scs_gpu not built
-
-
-def test_mkl_direct_tries_import():
-    """mkl=True, use_indirect=False should attempt to import _scs_mkl."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=False,
-                    verbose=False)
-        except ImportError:
-            pass  # Expected: _scs_mkl not built
-
-
-def test_select_module_pops_all_flags():
-    """Verify that _select_scs_module pops all legacy selection flags."""
-    stgs = {"use_indirect": False, "gpu": False, "mkl": False,
-            "cudss": False, "dense": False, "verbose": False}
-    scs.SCS(_make_data(), _CONE, **stgs)
-    # If any flag wasn't popped, the C extension would raise TypeError
+def test_select_module_pops_linear_solver():
+    """Verify that _select_scs_module pops linear_solver from settings."""
+    scs.SCS(_make_data(), _CONE,
+            linear_solver=scs.LinearSolver.QDLDL, verbose=False)
+    # If linear_solver wasn't popped, the C extension would raise TypeError
 
 
 # ===========================================================================
@@ -2914,24 +2860,6 @@ def test_linear_solver_dense_tries_import():
         pass  # Expected: _scs_dense not built
 
 
-def test_linear_solver_gpu_tries_import():
-    """linear_solver=GPU should attempt to import _scs_gpu."""
-    try:
-        scs.SCS(_make_data(), _CONE,
-                linear_solver=scs.LinearSolver.GPU, verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_gpu not built
-
-
-def test_linear_solver_cudss_tries_import():
-    """linear_solver=CUDSS should attempt to import _scs_cudss."""
-    try:
-        scs.SCS(_make_data(), _CONE,
-                linear_solver=scs.LinearSolver.CUDSS, verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_cudss not built
-
-
 def test_linear_solver_string():
     """linear_solver can be passed as a string."""
     solver = scs.SCS(_make_data(), _CONE,
@@ -2941,49 +2869,7 @@ def test_linear_solver_string():
 
 
 def test_linear_solver_default_is_auto():
-    """Not passing linear_solver (or any legacy flag) should use AUTO."""
+    """Not passing linear_solver should use AUTO."""
     solver = scs.SCS(_make_data(), _CONE, verbose=False)
     sol = solver.solve()
     assert sol["info"]["status"] == "solved"
-
-
-# ===========================================================================
-# 92. LinearSolver + legacy flags conflict
-# ===========================================================================
-
-
-def test_linear_solver_with_legacy_flag_raises():
-    """Passing both linear_solver and a legacy flag should raise ValueError."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(ValueError, match="Cannot combine"):
-            scs.SCS(_make_data(), _CONE,
-                    linear_solver=scs.LinearSolver.QDLDL,
-                    use_indirect=True, verbose=False)
-
-
-# ===========================================================================
-# 93. Legacy flags emit DeprecationWarning
-# ===========================================================================
-
-
-def test_legacy_use_indirect_warns():
-    """use_indirect=True should emit a DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match="deprecated"):
-        scs.SCS(_make_data(), _CONE, use_indirect=True, verbose=False)
-
-
-def test_legacy_mkl_warns():
-    """mkl=True should emit a DeprecationWarning."""
-    try:
-        with pytest.warns(DeprecationWarning, match="deprecated"):
-            scs.SCS(_make_data(), _CONE, mkl=True, verbose=False)
-    except ImportError:
-        pass  # _scs_mkl not built, but warning was still emitted
-
-
-def test_legacy_flags_all_false_no_warning():
-    """Legacy flags all set to False should NOT emit a DeprecationWarning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        scs.SCS(_make_data(), _CONE, verbose=False)

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -234,34 +234,42 @@ def test_P_full_symmetric_extracts_upper():
 
 def test_cudss_without_gpu_raises():
     """Passing cudss=True without gpu=True should raise ValueError."""
-    with pytest.raises(ValueError, match="gpu=True"):
-        scs.SCS(_make_data(), _CONE, cudss=True, verbose=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="gpu=True"):
+            scs.SCS(_make_data(), _CONE, cudss=True, verbose=False)
 
 
 def test_mkl_with_indirect_raises():
     """Passing mkl=True and use_indirect=True should raise NotImplementedError."""
-    try:
-        scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=True, verbose=False)
-        pytest.skip("_scs_mkl not built")
-    except NotImplementedError as exc:
-        assert "use_indirect=False" in str(exc)
-    except ImportError:
-        pytest.skip("_scs_mkl not built")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=True, verbose=False)
+            pytest.skip("_scs_mkl not built")
+        except NotImplementedError as exc:
+            assert "use_indirect=False" in str(exc)
+        except ImportError:
+            pytest.skip("_scs_mkl not built")
 
 
 def test_dense_with_indirect_raises():
     """Passing dense=True and use_indirect=True should raise ValueError."""
-    with pytest.raises(ValueError, match="use_indirect=False"):
-        scs.SCS(_make_data(), _CONE, dense=True, use_indirect=True, verbose=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="use_indirect=False"):
+            scs.SCS(_make_data(), _CONE, dense=True, use_indirect=True, verbose=False)
 
 
 def test_dense_direct_tries_import():
     """dense=True, use_indirect=False should attempt to import _scs_dense."""
-    try:
-        scs.SCS(_make_data(), _CONE, dense=True, use_indirect=False,
-                verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_dense not built
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, dense=True, use_indirect=False,
+                    verbose=False)
+        except ImportError:
+            pass  # Expected: _scs_dense not built
 
 
 # ===========================================================================
@@ -2213,53 +2221,63 @@ def test_negative_max_iters_raises():
 
 def test_cudss_true_gpu_true_indirect_true_raises():
     """cudss=True, gpu=True, use_indirect=True should raise ValueError."""
-    with pytest.raises(ValueError, match="gpu=True"):
-        scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
-                use_indirect=True, verbose=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="gpu=True"):
+            scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
+                    use_indirect=True, verbose=False)
 
 
 def test_cudss_true_gpu_true_indirect_false_tries_import():
     """cudss=True, gpu=True, use_indirect=False should attempt to import
     _scs_cudss (ImportError expected if not built)."""
-    try:
-        scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
-                use_indirect=False, verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_cudss not built
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, cudss=True, gpu=True,
+                    use_indirect=False, verbose=False)
+        except ImportError:
+            pass  # Expected: _scs_cudss not built
 
 
 def test_gpu_true_mkl_true_no_leak():
     """gpu=True, mkl=True should NOT leak 'mkl' kwarg into the C extension.
     The mkl flag must be popped before passing settings to C."""
-    try:
-        scs.SCS(_make_data(), _CONE, gpu=True, mkl=True, verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_gpu/_scs_cudss not built
-    # If mkl leaked through, the C extension would raise TypeError
-    # about unexpected kwarg. The ImportError (not TypeError) proves it
-    # was properly popped.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, gpu=True, mkl=True, verbose=False)
+        except ImportError:
+            pass  # Expected: _scs_gpu/_scs_cudss not built
+        # If mkl leaked through, the C extension would raise TypeError
+        # about unexpected kwarg. The ImportError (not TypeError) proves it
+        # was properly popped.
 
 
 def test_gpu_indirect_tries_import():
     """gpu=True, use_indirect=True should attempt to import _scs_gpu."""
-    try:
-        scs.SCS(_make_data(), _CONE, gpu=True, use_indirect=True,
-                verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_gpu not built
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, gpu=True, use_indirect=True,
+                    verbose=False)
+        except ImportError:
+            pass  # Expected: _scs_gpu not built
 
 
 def test_mkl_direct_tries_import():
     """mkl=True, use_indirect=False should attempt to import _scs_mkl."""
-    try:
-        scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=False,
-                verbose=False)
-    except ImportError:
-        pass  # Expected: _scs_mkl not built
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            scs.SCS(_make_data(), _CONE, mkl=True, use_indirect=False,
+                    verbose=False)
+        except ImportError:
+            pass  # Expected: _scs_mkl not built
 
 
 def test_select_module_pops_all_flags():
-    """Verify that _select_scs_module pops all five selection flags."""
+    """Verify that _select_scs_module pops all legacy selection flags."""
     stgs = {"use_indirect": False, "gpu": False, "mkl": False,
             "cudss": False, "dense": False, "verbose": False}
     scs.SCS(_make_data(), _CONE, **stgs)
@@ -2838,3 +2856,134 @@ def test_warm_start_true_x_y_s_on_first_solve():
     sol = solver.solve(warm_start=True, x=x0, y=y0, s=s0)
     assert sol["info"]["status"] == "solved"
     assert_almost_equal(sol["x"][0], 1.0, decimal=3)
+
+
+# ===========================================================================
+# 91. LinearSolver enum API
+# ===========================================================================
+
+
+def test_linear_solver_auto():
+    """linear_solver=AUTO should solve using the best available backend."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver=scs.LinearSolver.AUTO, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+def test_linear_solver_qdldl():
+    """linear_solver=QDLDL should use the direct QDLDL solver."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver=scs.LinearSolver.QDLDL, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+def test_linear_solver_indirect():
+    """linear_solver=INDIRECT should use the CG (indirect) solver."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver=scs.LinearSolver.INDIRECT, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+def test_linear_solver_mkl_tries_import():
+    """linear_solver=MKL should attempt to import _scs_mkl."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.MKL, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_mkl not built
+
+
+def test_linear_solver_accelerate_tries_import():
+    """linear_solver=ACCELERATE should attempt to import _scs_accelerate."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.ACCELERATE, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_accelerate not built
+
+
+def test_linear_solver_dense_tries_import():
+    """linear_solver=DENSE should attempt to import _scs_dense."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.DENSE, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_dense not built
+
+
+def test_linear_solver_gpu_tries_import():
+    """linear_solver=GPU should attempt to import _scs_gpu."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.GPU, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_gpu not built
+
+
+def test_linear_solver_cudss_tries_import():
+    """linear_solver=CUDSS should attempt to import _scs_cudss."""
+    try:
+        scs.SCS(_make_data(), _CONE,
+                linear_solver=scs.LinearSolver.CUDSS, verbose=False)
+    except ImportError:
+        pass  # Expected: _scs_cudss not built
+
+
+def test_linear_solver_string():
+    """linear_solver can be passed as a string."""
+    solver = scs.SCS(_make_data(), _CONE,
+                     linear_solver="qdldl", verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+def test_linear_solver_default_is_auto():
+    """Not passing linear_solver (or any legacy flag) should use AUTO."""
+    solver = scs.SCS(_make_data(), _CONE, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] == "solved"
+
+
+# ===========================================================================
+# 92. LinearSolver + legacy flags conflict
+# ===========================================================================
+
+
+def test_linear_solver_with_legacy_flag_raises():
+    """Passing both linear_solver and a legacy flag should raise ValueError."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="Cannot combine"):
+            scs.SCS(_make_data(), _CONE,
+                    linear_solver=scs.LinearSolver.QDLDL,
+                    use_indirect=True, verbose=False)
+
+
+# ===========================================================================
+# 93. Legacy flags emit DeprecationWarning
+# ===========================================================================
+
+
+def test_legacy_use_indirect_warns():
+    """use_indirect=True should emit a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        scs.SCS(_make_data(), _CONE, use_indirect=True, verbose=False)
+
+
+def test_legacy_mkl_warns():
+    """mkl=True should emit a DeprecationWarning."""
+    try:
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            scs.SCS(_make_data(), _CONE, mkl=True, verbose=False)
+    except ImportError:
+        pass  # _scs_mkl not built, but warning was still emitted
+
+
+def test_legacy_flags_all_false_no_warning():
+    """Legacy flags all set to False should NOT emit a DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        scs.SCS(_make_data(), _CONE, verbose=False)

--- a/test/test_scs_object.py
+++ b/test/test_scs_object.py
@@ -49,6 +49,7 @@ except ImportError:
     pass
 
 _solver_configs = [
+    {"linear_solver": scs.LinearSolver.AUTO},
     {"linear_solver": scs.LinearSolver.QDLDL},
     {"linear_solver": scs.LinearSolver.INDIRECT},
 ]

--- a/test/test_scs_object.py
+++ b/test/test_scs_object.py
@@ -49,11 +49,11 @@ except ImportError:
     pass
 
 _solver_configs = [
-    {"use_indirect": False},
-    {"use_indirect": True},
+    {"linear_solver": scs.LinearSolver.QDLDL},
+    {"linear_solver": scs.LinearSolver.INDIRECT},
 ]
 if _dense_available:
-    _solver_configs.append({"dense": True})
+    _solver_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _solver_configs)

--- a/test/test_scs_quad.py
+++ b/test/test_scs_quad.py
@@ -13,7 +13,7 @@ P = sp.csc_matrix([1.2345]).tocsc()
 data = {"A": A, "P": P, "b": b, "c": c}
 cone = {"q": [], "l": 2}
 
-sol = scs.solve(data, cone, use_indirect=False)
+sol = scs.solve(data, cone, linear_solver=scs.LinearSolver.QDLDL)
 print(sol)
-sol = scs.solve(data, cone, use_indirect=True)
+sol = scs.solve(data, cone, linear_solver=scs.LinearSolver.INDIRECT)
 print(sol)

--- a/test/test_scs_quad.py
+++ b/test/test_scs_quad.py
@@ -13,6 +13,8 @@ P = sp.csc_matrix([1.2345]).tocsc()
 data = {"A": A, "P": P, "b": b, "c": c}
 cone = {"q": [], "l": 2}
 
+sol = scs.solve(data, cone, linear_solver=scs.LinearSolver.AUTO)
+print(sol)
 sol = scs.solve(data, cone, linear_solver=scs.LinearSolver.QDLDL)
 print(sol)
 sol = scs.solve(data, cone, linear_solver=scs.LinearSolver.INDIRECT)

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -82,6 +82,7 @@ except ImportError:
     pass
 
 _solver_configs = [
+    {"linear_solver": scs.LinearSolver.AUTO},
     {"linear_solver": scs.LinearSolver.QDLDL},
     {"linear_solver": scs.LinearSolver.INDIRECT},
 ]

--- a/test/test_scs_rand.py
+++ b/test/test_scs_rand.py
@@ -82,11 +82,11 @@ except ImportError:
     pass
 
 _solver_configs = [
-    {"use_indirect": False},
-    {"use_indirect": True},
+    {"linear_solver": scs.LinearSolver.QDLDL},
+    {"linear_solver": scs.LinearSolver.INDIRECT},
 ]
 if _dense_available:
-    _solver_configs.append({"dense": True})
+    _solver_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _solver_configs)
@@ -109,9 +109,9 @@ def test_infeasible(solver_opts):
 
 
 # TODO: indirect solver has trouble in this test, so disable for now
-_unbounded_configs = [{"use_indirect": False}]
+_unbounded_configs = [{"linear_solver": scs.LinearSolver.QDLDL}]
 if _dense_available:
-    _unbounded_configs.append({"dense": True})
+    _unbounded_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _unbounded_configs)

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -82,6 +82,7 @@ except ImportError:
     pass
 
 _solver_configs = [
+    {"linear_solver": scs.LinearSolver.AUTO},
     {"linear_solver": scs.LinearSolver.QDLDL},
     {"linear_solver": scs.LinearSolver.INDIRECT},
 ]

--- a/test/test_scs_sdp.py
+++ b/test/test_scs_sdp.py
@@ -82,11 +82,11 @@ except ImportError:
     pass
 
 _solver_configs = [
-    {"use_indirect": False},
-    {"use_indirect": True},
+    {"linear_solver": scs.LinearSolver.QDLDL},
+    {"linear_solver": scs.LinearSolver.INDIRECT},
 ]
 if _dense_available:
-    _solver_configs.append({"dense": True})
+    _solver_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _solver_configs)
@@ -109,9 +109,9 @@ def test_infeasible(solver_opts):
 
 
 # TODO: indirect solver has trouble in this test, so disable for now
-_unbounded_configs = [{"use_indirect": False}]
+_unbounded_configs = [{"linear_solver": scs.LinearSolver.QDLDL}]
 if _dense_available:
-    _unbounded_configs.append({"dense": True})
+    _unbounded_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 
 @pytest.mark.parametrize("solver_opts", _unbounded_configs)

--- a/test/test_solve_random_cone_prob.py
+++ b/test/test_solve_random_cone_prob.py
@@ -21,11 +21,11 @@ except ImportError:
     import_error("Please install pytest to run tests.")
     raise
 
-flags = [(False, False), (True, False)]
+solvers = [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
 try:
-    import _scs_gpu
+    from scs import _scs_gpu
 
-    flags += [(True, True)]
+    solvers.append(scs.LinearSolver.GPU)
 except ImportError:
     pass
 
@@ -45,10 +45,10 @@ m = tools.get_scs_cone_dims(K)
 params = {"verbose": True, "eps_abs": 1e-7, "eps_rel": 1e-7, "eps_infeas": 1e-7}
 
 
-@pytest.mark.parametrize("use_indirect,gpu", flags)
-def test_solve_feasible(use_indirect, gpu):
+@pytest.mark.parametrize("linear_solver", solvers)
+def test_solve_feasible(linear_solver):
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
-    solver = scs.SCS(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    solver = scs.SCS(data, K, linear_solver=linear_solver, **params)
     sol = solver.solve()
     x = sol["x"]
     y = sol["y"]
@@ -66,10 +66,10 @@ def test_solve_feasible(use_indirect, gpu):
     np.testing.assert_almost_equal(y, tools.proj_dual_cone(y, K), decimal=3)
 
 
-@pytest.mark.parametrize("use_indirect,gpu", flags)
-def test_solve_infeasible(use_indirect, gpu):
+@pytest.mark.parametrize("linear_solver", solvers)
+def test_solve_infeasible(linear_solver):
     data = tools.gen_infeasible(K, n=m // 2)
-    solver = scs.SCS(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    solver = scs.SCS(data, K, linear_solver=linear_solver, **params)
     sol = solver.solve()
     y = sol["y"]
     np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
@@ -78,10 +78,10 @@ def test_solve_infeasible(use_indirect, gpu):
 
 
 # TODO: indirect solver has trouble in this test, so disable for now
-@pytest.mark.parametrize("use_indirect,gpu", [(False, False)])
-def test_solve_unbounded(use_indirect, gpu):
+@pytest.mark.parametrize("linear_solver", [scs.LinearSolver.QDLDL])
+def test_solve_unbounded(linear_solver):
     data = tools.gen_unbounded(K, n=m // 2)
-    solver = scs.SCS(data, K, use_indirect=use_indirect, gpu=gpu, **params)
+    solver = scs.SCS(data, K, linear_solver=linear_solver, **params)
     sol = solver.solve()
     x = sol["x"]
     s = sol["s"]

--- a/test/test_solve_random_cone_prob.py
+++ b/test/test_solve_random_cone_prob.py
@@ -21,7 +21,7 @@ except ImportError:
     import_error("Please install pytest to run tests.")
     raise
 
-solvers = [scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
+solvers = [scs.LinearSolver.AUTO, scs.LinearSolver.QDLDL, scs.LinearSolver.INDIRECT]
 try:
     from scs import _scs_gpu
 

--- a/test/test_solve_random_cone_prob_accelerate.py
+++ b/test/test_solve_random_cone_prob_accelerate.py
@@ -35,7 +35,7 @@ params = {"verbose": True, "eps_abs": 1e-7, "eps_rel": 1e-7, "eps_infeas": 1e-7}
 
 def test_solve_feasible():
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
-    solver = scs.SCS(data, K, apple_ldl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.ACCELERATE, **params)
     sol = solver.solve()
     x = sol["x"]
     y = sol["y"]
@@ -54,7 +54,7 @@ def test_solve_feasible():
 
 def test_solve_infeasible():
     data = tools.gen_infeasible(K, n=m // 2)
-    solver = scs.SCS(data, K, apple_ldl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.ACCELERATE, **params)
     sol = solver.solve()
     y = sol["y"]
     np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
@@ -64,7 +64,7 @@ def test_solve_infeasible():
 
 def test_solve_unbounded():
     data = tools.gen_unbounded(K, n=m // 2)
-    solver = scs.SCS(data, K, apple_ldl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.ACCELERATE, **params)
     sol = solver.solve()
     x = sol["x"]
     s = sol["s"]

--- a/test/test_solve_random_cone_prob_cudss.py
+++ b/test/test_solve_random_cone_prob_cudss.py
@@ -42,7 +42,7 @@ try:
 
     def test_solve_feasible():
         data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
-        solver = scs.SCS(data, K, cudss=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.CUDSS, **params)
         sol = solver.solve()
         x = sol["x"]
         y = sol["y"]
@@ -61,7 +61,7 @@ try:
 
     def test_solve_infeasible():
         data = tools.gen_infeasible(K, n=m // 2)
-        solver = scs.SCS(data, K, cudss=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.CUDSS, **params)
         sol = solver.solve()
         y = sol["y"]
         np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
@@ -70,7 +70,7 @@ try:
 
     def test_solve_unbounded():
         data = tools.gen_unbounded(K, n=m // 2)
-        solver = scs.SCS(data, K, cudss=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.CUDSS, **params)
         sol = solver.solve()
         x = sol["x"]
         s = sol["s"]

--- a/test/test_solve_random_cone_prob_dense.py
+++ b/test/test_solve_random_cone_prob_dense.py
@@ -42,7 +42,7 @@ try:
 
     def test_solve_feasible():
         data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
-        solver = scs.SCS(data, K, dense=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.DENSE, **params)
         sol = solver.solve()
         x = sol["x"]
         y = sol["y"]
@@ -61,7 +61,7 @@ try:
 
     def test_solve_infeasible():
         data = tools.gen_infeasible(K, n=m // 2)
-        solver = scs.SCS(data, K, dense=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.DENSE, **params)
         sol = solver.solve()
         y = sol["y"]
         np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
@@ -70,7 +70,7 @@ try:
 
     def test_solve_unbounded():
         data = tools.gen_unbounded(K, n=m // 2)
-        solver = scs.SCS(data, K, dense=True, **params)
+        solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.DENSE, **params)
         sol = solver.solve()
         x = sol["x"]
         s = sol["s"]

--- a/test/test_solve_random_cone_prob_mkl.py
+++ b/test/test_solve_random_cone_prob_mkl.py
@@ -43,7 +43,7 @@ params = {"verbose": True, "eps_abs": 1e-7, "eps_rel": 1e-7, "eps_infeas": 1e-7}
 
 def test_solve_feasible():
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1)
-    solver = scs.SCS(data, K, mkl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.MKL, **params)
     sol = solver.solve()
     x = sol["x"]
     y = sol["y"]
@@ -62,7 +62,7 @@ def test_solve_feasible():
 
 def test_solve_infeasible():
     data = tools.gen_infeasible(K, n=m // 2)
-    solver = scs.SCS(data, K, mkl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.MKL, **params)
     sol = solver.solve()
     y = sol["y"]
     np.testing.assert_array_less(np.linalg.norm(data["A"].T @ y), 1e-3)
@@ -72,7 +72,7 @@ def test_solve_infeasible():
 
 def test_solve_unbounded():
     data = tools.gen_unbounded(K, n=m // 2)
-    solver = scs.SCS(data, K, mkl=True, **params)
+    solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.MKL, **params)
     sol = solver.solve()
     x = sol["x"]
     s = sol["s"]

--- a/test/test_spectral_and_complex_cones.py
+++ b/test/test_spectral_and_complex_cones.py
@@ -92,11 +92,11 @@ except ImportError:
     pass
 
 _solver_configs = [
-    {"use_indirect": False},
-    {"use_indirect": True},
+    {"linear_solver": scs.LinearSolver.QDLDL},
+    {"linear_solver": scs.LinearSolver.INDIRECT},
 ]
 if _dense_available:
-    _solver_configs.append({"dense": True})
+    _solver_configs.append({"linear_solver": scs.LinearSolver.DENSE})
 
 skip_no_spectral = pytest.mark.skipif(
     not _spectral_available,

--- a/test/test_spectral_and_complex_cones.py
+++ b/test/test_spectral_and_complex_cones.py
@@ -92,6 +92,7 @@ except ImportError:
     pass
 
 _solver_configs = [
+    {"linear_solver": scs.LinearSolver.AUTO},
     {"linear_solver": scs.LinearSolver.QDLDL},
     {"linear_solver": scs.LinearSolver.INDIRECT},
 ]


### PR DESCRIPTION
## Summary

Replaces the boolean flags (`gpu`, `mkl`, `apple_ldl`, `dense`, `cudss`,
`use_indirect`) with a single `linear_solver` parameter that takes a
`scs.LinearSolver` enum value (also accepts strings).

Available solvers: `AUTO`, `QDLDL`, `INDIRECT`, `MKL`, `ACCELERATE`, `DENSE`,
`GPU`, `CUDSS`.

The default is `AUTO`, which auto-detects the best available direct solver:
- **macOS**: Apple Accelerate if built, otherwise QDLDL
- **Linux/Windows**: MKL Pardiso if built, otherwise QDLDL

### Usage

```python
import scs

# Auto-detect best backend (default)
solver = scs.SCS(data, cone)

# Explicitly select a solver
solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.MKL)

# String values also work
solver = scs.SCS(data, cone, linear_solver="indirect")
```

### Implementation

Module selection uses dict dispatch for clean, extensible mapping:

```python
_SOLVER_DISPATCH = {
    LinearSolver.AUTO: _resolve_auto,
    LinearSolver.QDLDL: lambda: _scs_direct,
    LinearSolver.INDIRECT: lambda: _load_module("_scs_indirect"),
    LinearSolver.MKL: lambda: _load_module("_scs_mkl"),
    ...
}

def _select_scs_module(stgs):
    linear_solver = stgs.pop("linear_solver", LinearSolver.AUTO)
    if isinstance(linear_solver, str):
        linear_solver = LinearSolver(linear_solver)
    return _SOLVER_DISPATCH[linear_solver]()
```

This is a breaking API change: the old boolean flags are removed, not deprecated.

## Test plan
- [x] All 250 tests pass with zero warnings
- [x] Updated all 16 test files to use new `linear_solver=` API
- [x] Tests for each `LinearSolver` enum value (QDLDL, INDIRECT, MKL, ACCELERATE, DENSE, GPU, CUDSS)
- [x] Test string values work (`linear_solver="qdldl"`)
- [x] Test `AUTO` default works when no solver is specified
- [x] Test invalid string raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)