### PR TITLE
Add MKL BLAS64 support and multi-threaded PARDISO in wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           else
             BLAS_PKGS="blas-devel=*=*openblas"
           fi
-          pixi add --platform linux-64 $BLAS_PKGS pip scipy numpy pytest mkl mkl-devel intel-openmp pkg-config meson meson-python
+          pixi add --platform linux-64 $BLAS_PKGS pip scipy numpy pytest mkl mkl-devel pkg-config meson meson-python
       - name: Build
         run: |
           pixi r python -c "import numpy as np;print(np.show_config())"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           else
             BLAS_PKGS="blas-devel=*=*openblas"
           fi
-          pixi add --platform linux-64 $BLAS_PKGS pip scipy numpy pytest mkl mkl-devel pkg-config meson meson-python
+          pixi add --platform linux-64 $BLAS_PKGS pip scipy numpy pytest mkl mkl-devel intel-openmp pkg-config meson meson-python
       - name: Build
         run: |
           pixi r python -c "import numpy as np;print(np.show_config())"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,12 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         link_mkl: [true]
+        use_blas64: [true, false]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       LINK_MKL: ${{ matrix.link_mkl }}
+      USE_BLAS64: ${{ matrix.use_blas64 }}
 
     steps:
       - uses: actions/checkout@v6
@@ -90,12 +92,11 @@ jobs:
       - name: Build
         run: |
           pixi r python -c "import numpy as np;print(np.show_config())"
-          if [[ "$LINK_MKL" == "true" ]]; then
-
-            pixi r python -m pip install --verbose --no-build-isolation -Csetup-args=-Dlink_mkl=true .
-          else
-            pixi r python -m pip install --verbose --no-build-isolation .
+          MESON_ARGS="-Csetup-args=-Dlink_mkl=true"
+          if [[ "$USE_BLAS64" == "true" ]]; then
+            MESON_ARGS="$MESON_ARGS -Csetup-args=-Duse_blas64=true"
           fi
+          pixi r python -m pip install --verbose --no-build-isolation $MESON_ARGS .
       - name: Test
         run: |
           pixi r pytest
@@ -198,7 +199,7 @@ jobs:
 
       - name: Install MKL from conda on Windows
         if: runner.os == 'Windows'
-        run: conda install -y -c https://software.repos.intel.com/python/conda/ -c conda-forge mkl mkl-devel pkgconfig
+        run: conda install -y -c https://software.repos.intel.com/python/conda/ -c conda-forge mkl mkl-devel intel-openmp pkgconfig
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ backends can be enabled with build-time flags:
 # MKL Pardiso direct solver
 pip install . -Csetup-args=-Dlink_mkl=true
 
+# Use 64-bit BLAS/LAPACK integers (ILP64 / BLAS64)
+pip install . -Csetup-args=-Duse_blas64=true
+
 # GPU direct solver (cuDSS)
 pip install . -Csetup-args=-Dlink_cudss=true -Csetup-args=-Dint32=true
 
@@ -57,6 +60,11 @@ pip install . -Csetup-args=-Duse_lapack=true
 # Spectral cones (logdet, nuclear norm, ell-1, sum-of-largest)
 pip install . -Csetup-args=-Duse_spectral_cones=true
 ```
+
+Notes:
+- Linux x86_64 wheels are built and tested against threaded MKL, and CI asserts a `libiomp5` dependency on the packaged `_scs_mkl` extension. Windows currently falls back to sequential MKL because Intel's conda `pkg-config` metadata for the threaded variant is still broken.
+- `BLAS64` is a general SCS build mode for ILP64 BLAS/LAPACK libraries, not an MKL-only feature.
+- For the MKL Pardiso backend specifically, `BLAS64` must be paired with 64-bit SCS integers (`DLONG` / `int32=false`), and SCS now fails early if another library in the process has already fixed MKL to an incompatible LP64/ILP64 interface layer.
 
 ## Usage
 

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,6 @@ print(incdir)
 
 # Get BLAS
 blas_deps = []
-mkl_force_sequential = false
 mkl_pkg_name = ''
 if get_option('link_mkl')
     if get_option('use_blas64') and get_option('int32')
@@ -53,7 +52,6 @@ if get_option('link_mkl')
         # without -I prefix). Use sequential MKL until Intel ships a fix.
         blas_deps = [dependency(_mkl_seq, required : false)]
         if blas_deps[0].found()
-            mkl_force_sequential = true
             mkl_pkg_name = _mkl_seq
         endif
     else
@@ -61,7 +59,6 @@ if get_option('link_mkl')
         if not blas_deps[0].found()
             blas_deps = [dependency(_mkl_seq, required : false)]
             if blas_deps[0].found()
-                mkl_force_sequential = true
                 mkl_pkg_name = _mkl_seq
             endif
         else
@@ -340,10 +337,6 @@ if get_option('link_mkl')
     error('link_mkl=true requires mkl_rt (or mkl-sdl). _scs_mkl calls MKL_Set_Interface_Layer() at startup and cannot be built safely without it.')
   endif
   _mkl_deps += mkl_rt_dep
-  _mkl_c_args = common_c_args + ['-DPY_MKL']
-  if mkl_force_sequential
-    _mkl_c_args += '-DSCS_MKL_FORCE_SEQUENTIAL=1'
-  endif
   py.extension_module(
     '_scs_mkl',
     'scs/scspy.c',
@@ -351,7 +344,7 @@ if get_option('link_mkl')
     common_linsys_sources,
     scs_core_sources,
     spectral_cone_sources,
-    c_args: _mkl_c_args,
+    c_args: common_c_args + ['-DPY_MKL'],
     include_directories: common_includes + ['scs_source/linsys/mkl/direct'],
     dependencies: _mkl_deps,
     install_dir: scs_dir,

--- a/meson.build
+++ b/meson.build
@@ -23,17 +23,41 @@ print(incdir)
 # Get BLAS
 blas_deps = []
 if get_option('link_mkl')
-    # Prefer component libraries (lp64, sequential) so that wheel-repair
-    # tools (auditwheel / delvewheel) can detect and bundle them.
-    blas_deps = [dependency('mkl-dynamic-lp64-seq', required : false)]
+    # Link against MKL component libraries. The integer width must match:
+    #   use_blas64=false (default) -> LP64  (32-bit BLAS integers)
+    #   use_blas64=true            -> ILP64 (64-bit BLAS integers)
+    #
+    # Note: PARDISO integer width is independent — it is controlled by the
+    # pardiso vs pardiso_64 entry point (selected via DLONG), not by the
+    # interface layer. See linsys/mkl/direct/private.c for details.
+    # Prefer Intel OpenMP (iomp) for multi-threaded MKL, fall back to
+    # sequential if iomp is not available.
+    #
+    # TODO: On Windows the conda MKL iomp .pc file (mkl-dynamic-*-iomp)
+    # has broken Cflags (raw path without -I prefix). Revisit once Intel
+    # ships a fixed pkg-config file; until then Windows gets sequential MKL.
+    if get_option('use_blas64')
+        _mkl_iomp = 'mkl-dynamic-ilp64-iomp'
+        _mkl_seq = 'mkl-dynamic-ilp64-seq'
+    else
+        _mkl_iomp = 'mkl-dynamic-lp64-iomp'
+        _mkl_seq = 'mkl-dynamic-lp64-seq'
+    endif
+    if host_machine.system() == 'windows'
+        # On Windows the conda MKL iomp .pc file has broken Cflags (raw path
+        # without -I prefix). Use sequential MKL until Intel ships a fix.
+        blas_deps = [dependency(_mkl_seq, required : false)]
+    else
+        blas_deps = [dependency(_mkl_iomp, required : false)]
+        if not blas_deps[0].found()
+            blas_deps = [dependency(_mkl_seq, required : false)]
+        endif
+    endif
     if not blas_deps[0].found()
         blas_deps = [cc.find_library('mkl_rt', required : false)]
     endif
     if not blas_deps[0].found()
         blas_deps = [dependency('mkl-sdl', required : false)]
-    endif
-    if not blas_deps[0].found()
-      blas_deps = [ dependency('mkl-dynamic-ilp64-iomp', required: false) ]
     endif
 else
     if host_machine.system() == 'darwin'
@@ -276,6 +300,28 @@ if get_option('use_gpu')
 endif
 
 if get_option('link_mkl')
+  # The MKL backend calls MKL_Set_Interface_Layer() for a runtime interface
+  # check. This symbol is only exported by mkl_rt (the single dynamic library),
+  # not by component libraries (mkl_intel_lp64 etc.) that pkg-config may link.
+  # Add mkl_rt explicitly so the symbol is always available.
+  _mkl_deps = _deps
+  mkl_rt_dep = dependency('mkl-sdl', required : false)
+  if not mkl_rt_dep.found()
+    mkl_rt_dep = cc.find_library('mkl_rt', required : false)
+  endif
+  if not mkl_rt_dep.found()
+    # Extract lib directory from pkg-config and search there
+    _mkl_libdir = run_command('pkg-config', '--variable=libdir', 'mkl-dynamic-lp64-seq',
+                              check: false).stdout().strip()
+    if _mkl_libdir != ''
+      mkl_rt_dep = cc.find_library('mkl_rt', dirs: [_mkl_libdir], required : false)
+    endif
+  endif
+  if mkl_rt_dep.found()
+    _mkl_deps += mkl_rt_dep
+  else
+    warning('mkl_rt not found — MKL_Set_Interface_Layer runtime check will not be available')
+  endif
   py.extension_module(
     '_scs_mkl',
     'scs/scspy.c',
@@ -285,7 +331,7 @@ if get_option('link_mkl')
     spectral_cone_sources,
     c_args: common_c_args + ['-DPY_MKL'],
     include_directories: common_includes + ['scs_source/linsys/mkl/direct'],
-    dependencies: _deps,
+    dependencies: _mkl_deps,
     install_dir: scs_dir,
     install: true,
   )

--- a/meson.build
+++ b/meson.build
@@ -110,10 +110,6 @@ if not blas_deps[0].found() and not get_option('sdist_mode')
     error('OpenBLAS or Netlib BLAS/CBLAS is required on all platforms, and was not found.')
 endif
 
-if get_option('use_blas64') and not get_option('link_mkl')
-  error('use_blas64 is currently only supported for MKL builds. Re-run Meson with -Dlink_mkl=true or -Duse_blas64=false.')
-endif
-
 # Common
 common_c_args = cc.get_supported_arguments(
   '-Wno-unused-result',
@@ -344,7 +340,7 @@ if get_option('link_mkl')
     common_linsys_sources,
     scs_core_sources,
     spectral_cone_sources,
-    c_args: common_c_args + ['-DPY_MKL'],
+    c_args: common_c_args + ['-DPY_MKL', '-DSCS_MKL=1'],
     include_directories: common_includes + ['scs_source/linsys/mkl/direct'],
     dependencies: _mkl_deps,
     install_dir: scs_dir,

--- a/meson.build
+++ b/meson.build
@@ -316,15 +316,13 @@ if get_option('link_mkl')
   # check. This symbol is only exported by mkl_rt (the single dynamic library),
   # not by component libraries (mkl_intel_lp64 etc.) that pkg-config may link.
   # Add mkl_rt explicitly so the symbol is always available.
-  _mkl_deps = _deps
   mkl_rt_dep = dependency('mkl-sdl', required : false)
   if not mkl_rt_dep.found()
     mkl_rt_dep = cc.find_library('mkl_rt', required : false)
   endif
   if not mkl_rt_dep.found() and mkl_pkg_name != ''
-    # Extract lib directory from pkg-config and search there
-    _mkl_libdir = run_command('pkg-config', '--variable=libdir', mkl_pkg_name,
-                              check: false).stdout().strip()
+    # Search next to the pkg-config-provided MKL component libraries.
+    _mkl_libdir = blas_deps[0].get_variable(pkgconfig: 'libdir', default_value: '')
     if _mkl_libdir != ''
       mkl_rt_dep = cc.find_library('mkl_rt', dirs: [_mkl_libdir], required : false)
     endif
@@ -332,7 +330,7 @@ if get_option('link_mkl')
   if not mkl_rt_dep.found()
     error('link_mkl=true requires mkl_rt (or mkl-sdl). _scs_mkl calls MKL_Set_Interface_Layer() at startup and cannot be built safely without it.')
   endif
-  _mkl_deps += mkl_rt_dep
+  _mkl_deps = _deps + [mkl_rt_dep]
   py.extension_module(
     '_scs_mkl',
     'scs/scspy.c',

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,12 @@ print(incdir)
 
 # Get BLAS
 blas_deps = []
+mkl_force_sequential = false
+mkl_pkg_name = ''
 if get_option('link_mkl')
+    if get_option('use_blas64') and get_option('int32')
+        error('MKL BLAS64 requires 64-bit SCS integers. Re-run Meson with -Dint32=false.')
+    endif
     # Link against MKL component libraries. The integer width must match:
     #   use_blas64=false (default) -> LP64  (32-bit BLAS integers)
     #   use_blas64=true            -> ILP64 (64-bit BLAS integers)
@@ -47,10 +52,20 @@ if get_option('link_mkl')
         # On Windows the conda MKL iomp .pc file has broken Cflags (raw path
         # without -I prefix). Use sequential MKL until Intel ships a fix.
         blas_deps = [dependency(_mkl_seq, required : false)]
+        if blas_deps[0].found()
+            mkl_force_sequential = true
+            mkl_pkg_name = _mkl_seq
+        endif
     else
         blas_deps = [dependency(_mkl_iomp, required : false)]
         if not blas_deps[0].found()
             blas_deps = [dependency(_mkl_seq, required : false)]
+            if blas_deps[0].found()
+                mkl_force_sequential = true
+                mkl_pkg_name = _mkl_seq
+            endif
+        else
+            mkl_pkg_name = _mkl_iomp
         endif
     endif
     if not blas_deps[0].found()
@@ -96,6 +111,10 @@ endif
 # When creating an sdist we are not compiling / linking, so don't need to fail.
 if not blas_deps[0].found() and not get_option('sdist_mode')
     error('OpenBLAS or Netlib BLAS/CBLAS is required on all platforms, and was not found.')
+endif
+
+if get_option('use_blas64') and not get_option('link_mkl')
+  error('use_blas64 is currently only supported for MKL builds. Re-run Meson with -Dlink_mkl=true or -Duse_blas64=false.')
 endif
 
 # Common
@@ -309,18 +328,21 @@ if get_option('link_mkl')
   if not mkl_rt_dep.found()
     mkl_rt_dep = cc.find_library('mkl_rt', required : false)
   endif
-  if not mkl_rt_dep.found()
+  if not mkl_rt_dep.found() and mkl_pkg_name != ''
     # Extract lib directory from pkg-config and search there
-    _mkl_libdir = run_command('pkg-config', '--variable=libdir', 'mkl-dynamic-lp64-seq',
+    _mkl_libdir = run_command('pkg-config', '--variable=libdir', mkl_pkg_name,
                               check: false).stdout().strip()
     if _mkl_libdir != ''
       mkl_rt_dep = cc.find_library('mkl_rt', dirs: [_mkl_libdir], required : false)
     endif
   endif
-  if mkl_rt_dep.found()
-    _mkl_deps += mkl_rt_dep
-  else
-    warning('mkl_rt not found — MKL_Set_Interface_Layer runtime check will not be available')
+  if not mkl_rt_dep.found()
+    error('link_mkl=true requires mkl_rt (or mkl-sdl). _scs_mkl calls MKL_Set_Interface_Layer() at startup and cannot be built safely without it.')
+  endif
+  _mkl_deps += mkl_rt_dep
+  _mkl_c_args = common_c_args + ['-DPY_MKL']
+  if mkl_force_sequential
+    _mkl_c_args += '-DSCS_MKL_FORCE_SEQUENTIAL=1'
   endif
   py.extension_module(
     '_scs_mkl',
@@ -329,7 +351,7 @@ if get_option('link_mkl')
     common_linsys_sources,
     scs_core_sources,
     spectral_cone_sources,
-    c_args: common_c_args + ['-DPY_MKL'],
+    c_args: _mkl_c_args,
     include_directories: common_includes + ['scs_source/linsys/mkl/direct'],
     dependencies: _mkl_deps,
     install_dir: scs_dir,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ before-all = [
   "rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB",
   "dnf install -y intel-oneapi-mkl-devel",
 ]
-environment = {PKG_CONFIG_PATH = "/opt/intel/oneapi/mkl/latest/lib/pkgconfig:$PKG_CONFIG_PATH", LD_LIBRARY_PATH = "/opt/intel/oneapi/mkl/latest/lib/intel64:/opt/intel/oneapi/mkl/latest/lib:$LD_LIBRARY_PATH"}
+environment = {PKG_CONFIG_PATH = "/opt/intel/oneapi/mkl/latest/lib/pkgconfig:/opt/intel/oneapi/compiler/latest/lib/pkgconfig:$PKG_CONFIG_PATH", LD_LIBRARY_PATH = "/opt/intel/oneapi/mkl/latest/lib/intel64:/opt/intel/oneapi/mkl/latest/lib:/opt/intel/oneapi/compiler/latest/lib:$LD_LIBRARY_PATH"}
 config-settings = {setup-args = "-Dlink_mkl=true"}
 
 [[tool.cibuildwheel.overrides]]

--- a/test/test_solve_random_cone_prob_mkl.py
+++ b/test/test_solve_random_cone_prob_mkl.py
@@ -1,4 +1,6 @@
 from __future__ import print_function, division
+import os
+import subprocess
 import sys
 import platform
 import scs
@@ -39,6 +41,15 @@ K = {
 }
 m = tools.get_scs_cone_dims(K)
 params = {"verbose": True, "eps_abs": 1e-7, "eps_rel": 1e-7, "eps_infeas": 1e-7}
+
+
+@pytest.mark.skipif(
+    not (sys.platform == "linux" and platform.machine() == "x86_64"),
+    reason="Threaded MKL linkage is only checked on Linux x86_64",
+)
+def test_mkl_module_links_intel_openmp():
+    out = subprocess.check_output(["ldd", os.fspath(_scs_mkl.__file__)], text=True)
+    assert "libiomp5" in out
 
 
 def test_solve_feasible():


### PR DESCRIPTION
## Summary

- update `scs_source` to the matching `cvxgrp/scs#383` MKL runtime and `BLAS64` fixes
- make Meson select the correct LP64 vs ILP64 MKL libraries for `_scs_mkl`
- prefer threaded MKL for Linux x86_64 wheels and test that the packaged module links `libiomp5`
- keep Windows on sequential MKL for now because Intel's conda `pkg-config` metadata for the threaded variant is still broken

Depends on cvxgrp/scs#383.

## What changed

### 1. Match the native MKL contract from `scs`

This PR picks up the `scs_source` changes from `cvxgrp/scs#383`, including:

- early MKL interface-layer checking for LP64 vs ILP64 conflicts
- MKL-only startup initialization instead of a generic backend hook
- explicit CMake ILP64 handling for `BLAS64`

That gives the Python extension the same fail-fast behavior as the native library when another library in the process has already fixed MKL to an incompatible interface layer.

### 2. Meson MKL library selection

For `_scs_mkl`, Meson now chooses MKL libraries based on `use_blas64`:

- `use_blas64=false` -> LP64 MKL
- `use_blas64=true` -> ILP64 MKL

and it rejects the invalid MKL combination:

- `link_mkl=true` with `use_blas64=true` and `int32=true`

because MKL PARDISO with ILP64 BLAS also requires 64-bit SCS integers.

`_scs_mkl` is compiled with `SCS_MKL=1` so the early runtime interface-layer check from `scs_source` is enabled for the Python MKL extension as well.

### 3. Threaded MKL in Linux x86_64 wheels

For manylinux x86_64 wheels, the build now exposes both the MKL and Intel compiler `pkg-config` directories via `PKG_CONFIG_PATH`, plus the corresponding runtime library directories via `LD_LIBRARY_PATH`.

That lets Meson find the threaded MKL pkg-config targets, so the packaged Linux x86_64 wheel prefers the threaded MKL variant instead of silently ending up sequential.

There is also a Python test that inspects the packaged `_scs_mkl` extension with `ldd` and asserts that `libiomp5` is present on Linux x86_64.

### 4. Windows fallback remains sequential

Windows still uses the sequential MKL pkg-config target for now.

The reason is unchanged: Intel's conda `mkl-dynamic-*-iomp` pkg-config metadata on Windows currently has broken `Cflags`, so the threaded variant is not reliable there yet. The PR documents this explicitly rather than pretending Windows is on the same threaded path as Linux x86_64.

### 5. CI coverage

- the Linux MKL source-build matrix tests both `use_blas64=true` and `false`
- the manylinux x86_64 wheel path exercises the threaded MKL packaging configuration
- the packaged MKL module is checked for a `libiomp5` dependency on Linux x86_64

## Notes

`use_blas64` remains a general SCS build mode for ILP64 BLAS/LAPACK libraries. The special rule here is narrower: for the MKL PARDISO backend, ILP64 also requires 64-bit SCS integers.
