### PR TITLE
Surface informative TypeError from PyArg_Parse* instead of generic ValueError

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -422,8 +422,11 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
           &(stgs->acceleration_interval),
           &(stgs->write_data_filename),
           &(stgs->log_csv_filename))) {
+    /* PyArg_ParseTupleAndKeywords already set an informative TypeError
+     * (e.g. "argument 14 must be int, not str"). Overwriting it with a
+     * generic ValueError would hide which input was rejected. */
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("Error parsing inputs\n");
+    return -1;
   }
   /* clang-format on */
 
@@ -721,7 +724,8 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
                         &warm_x,
                         &warm_y,
                         &warm_s)) {
-    return none_with_error("Error parsing inputs");
+    /* PyArg_ParseTuple already set an informative TypeError; propagate it. */
+    return (PyObject *)NULL;
   }
   /* clang-format on */
 
@@ -876,7 +880,8 @@ PyObject *SCS_update(SCS *self, PyObject *args) {
 
   /* b, c can be None, so don't check is PyArray_Type */
   if (!PyArg_ParseTuple(args, "OO", &b_new, &c_new)) {
-    return none_with_error("Error parsing inputs");
+    /* PyArg_ParseTuple already set an informative TypeError; propagate it. */
+    return (PyObject *)NULL;
   }
   /* set c */
   if (!Py_IsNone((PyObject *)c_new)) {

--- a/test/test_scs_basic.py
+++ b/test/test_scs_basic.py
@@ -105,7 +105,9 @@ def test_failures():
 
     # python 2.6 and before just cast float to int
     if platform.python_version_tuple() >= ("2", "7", "0"):
-        with pytest.raises(ValueError):
+        # Native TypeError surfaced from PyArg_ParseTupleAndKeywords
+        # ("'float' object cannot be interpreted as an integer").
+        with pytest.raises(TypeError):
             scs.solve(data, {"q": [], "l": 2}, max_iters=1.1)
 
     with pytest.raises(ValueError):

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -1024,8 +1024,10 @@ def test_scale_zero_raises():
 
 
 def test_max_iters_non_integer_raises():
-    """Non-integer max_iters should raise ValueError."""
-    with pytest.raises(ValueError):
+    """Non-integer max_iters should raise TypeError with a message naming
+    the expected type — propagated from PyArg_ParseTupleAndKeywords
+    rather than clobbered by a generic ValueError."""
+    with pytest.raises(TypeError, match="integer"):
         scs.SCS(_make_data(), _CONE, max_iters=1.5)
 
 

--- a/test/test_scs_object.py
+++ b/test/test_scs_object.py
@@ -108,3 +108,26 @@ def test_warm_start(solver_opts):
 
     with pytest.raises(ValueError):
         sol = solver.solve(x=np.array([1.0, 2.0]))
+
+
+@pytest.mark.parametrize(
+    "bad_kwarg,expected_in_msg",
+    [
+        ({"max_iters": "not_an_int"}, "integer"),
+        ({"scale": "not_a_float"}, "real number"),
+        ({"eps_abs": object()}, "real number"),
+        ({"time_limit_secs": []}, "real number"),
+        ({"acceleration_lookback": 1.5}, "integer"),
+    ],
+)
+def test_init_type_error_is_informative(bad_kwarg, expected_in_msg):
+    """Bad-typed settings should surface the native TypeError from
+    PyArg_ParseTupleAndKeywords naming the expected type, not the old
+    catch-all 'Error parsing inputs' ValueError."""
+    with pytest.raises(TypeError) as exc_info:
+        scs.SCS(data, cone, verbose=False, **bad_kwarg)
+    msg = str(exc_info.value)
+    assert expected_in_msg in msg, (
+        f"expected {expected_in_msg!r} in error message, got: {msg!r}"
+    )
+    assert "Error parsing inputs" not in msg


### PR DESCRIPTION
## Summary

- `PyArg_ParseTupleAndKeywords` / `PyArg_ParseTuple` already raise a descriptive `TypeError` on failure (e.g. `"'str' object cannot be interpreted as an integer"`, `"must be real number, not list"`). Three sites in `scsobject.h` then called `finish_with_error`/`none_with_error("Error parsing inputs\n")` — which overwrote that with a generic `ValueError` and hid which input was rejected.
- Drop the overwrite in `SCS_init`, `SCS_solve`, `SCS_update`; let the native exception propagate.
- Add a parametrized test covering `max_iters`, `scale`, `eps_abs`, `time_limit_secs`, `acceleration_lookback`. Update the two existing tests (`test_failures`, `test_max_iters_non_integer_raises`) whose `ValueError` expectation encoded the clobbered-error behavior.

Before:

```
ValueError: Error parsing inputs
```

After:

```
TypeError: 'float' object cannot be interpreted as an integer
TypeError: must be real number, not str
```

## Test plan

- [x] `pytest test/test_scs_basic.py test/test_scs_object.py test/test_scs_rand.py test/test_scs_quad.py test/test_warm_start_consistency.py test/test_scs_coverage.py` — 252 passed locally (miniconda Python 3.13, editable install)
- [ ] CI on Linux/macOS/Windows across supported Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)