### PR TITLE
Proper DeprecationWarning for 'f' cone + tighten settings validation

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -537,12 +537,12 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
   }
   /* clang-format on */
 
-  if (d->m < 0) {
+  if (d->m <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("m must be a positive integer");
   }
 
-  if (d->n < 0) {
+  if (d->n <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("n must be a positive integer");
   }
@@ -664,11 +664,16 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     return finish_with_error("Failed to parse cone field z");
   }
   if (f_tmp > 0) {
-    scs_printf("SCS deprecation warning: The 'f' field in the cone struct \n"
-               "has been replaced by 'z' to better reflect the Zero cone. \n"
-               "Please replace usage of 'f' with 'z'. If both 'f' and 'z' \n"
-               "are set then we sum the two fields to get the final zero \n"
-               "cone size.\n");
+    /* PyErr_WarnEx returns -1 if the warning was promoted to an exception
+     * (e.g. warnings.filterwarnings("error")); in that case the exception
+     * is already set, so we just need to clean up and return -1. */
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The 'f' cone field is deprecated; use 'z' (Zero cone) "
+                     "instead. If both 'f' and 'z' are set they are summed.",
+                     1) < 0) {
+      free_py_scs_data(d, k, stgs, &ps);
+      return -1;
+    }
     k->z += f_tmp;
   }
   if (get_pos_int_param("l", &(k->l), 0, cone) < 0) {
@@ -768,14 +773,18 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
                              ? (scs_int)PyObject_IsTrue(adaptive_scale)
                              : ADAPTIVE_SCALE;
 
-  if (stgs->max_iters < 0) {
+  /* Ranges below match SCS's own validate() in scs_source/src/scs.c.
+   * Duplicated here so users get a Python exception naming the offending
+   * setting, rather than SCS's scs_printf + generic "ScsWork allocation
+   * error" fallback. */
+  if (stgs->max_iters <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("max_iters must be positive");
   }
   /* acceleration_lookback: positive selects type-I AA, negative selects
    * type-II; the magnitude is used as the memory size. Zero disables
    * acceleration. Passed through unchanged — see scs.c's aa_init call. */
-  if (stgs->acceleration_interval < 0) {
+  if (stgs->acceleration_interval <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_interval must be positive");
   }
@@ -789,21 +798,21 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
   }
   if (stgs->eps_abs < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_abs must be positive");
+    return finish_with_error("eps_abs must be nonnegative");
   }
   if (stgs->eps_rel < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_rel must be positive");
+    return finish_with_error("eps_rel must be nonnegative");
   }
   if (stgs->eps_infeas < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_infeas must be positive");
+    return finish_with_error("eps_infeas must be nonnegative");
   }
-  if (stgs->alpha < 0) {
+  if (stgs->alpha <= 0 || stgs->alpha >= 2) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("alpha must be positive");
+    return finish_with_error("alpha must be in (0, 2)");
   }
-  if (stgs->rho_x < 0) {
+  if (stgs->rho_x <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("rho_x must be positive");
   }

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -1012,15 +1012,39 @@ def test_soc_known_solution():
 
 
 def test_max_iters_zero_raises():
-    """max_iters=0 is invalid and should raise ValueError."""
-    with pytest.raises(ValueError):
-        scs.SCS(_make_data(), _CONE, max_iters=0, verbose=False).solve()
+    """max_iters=0 is invalid and should raise ValueError at __init__."""
+    with pytest.raises(ValueError, match="max_iters must be positive"):
+        scs.SCS(_make_data(), _CONE, max_iters=0, verbose=False)
 
 
 def test_scale_zero_raises():
-    """scale=0 is invalid and should raise ValueError."""
-    with pytest.raises(ValueError):
-        scs.SCS(_make_data(), _CONE, scale=0.0, verbose=False).solve()
+    """scale=0 is invalid and should raise ValueError at __init__."""
+    with pytest.raises(ValueError, match="scale must be positive"):
+        scs.SCS(_make_data(), _CONE, scale=0.0, verbose=False)
+
+
+def test_alpha_zero_raises():
+    """alpha=0 is outside the valid (0, 2) range for Douglas-Rachford."""
+    with pytest.raises(ValueError, match=r"alpha must be in \(0, 2\)"):
+        scs.SCS(_make_data(), _CONE, alpha=0.0, verbose=False)
+
+
+def test_alpha_two_raises():
+    """alpha=2 is outside the valid (0, 2) range."""
+    with pytest.raises(ValueError, match=r"alpha must be in \(0, 2\)"):
+        scs.SCS(_make_data(), _CONE, alpha=2.0, verbose=False)
+
+
+def test_rho_x_zero_raises():
+    """rho_x=0 is invalid — the primal regularizer must be positive."""
+    with pytest.raises(ValueError, match="rho_x must be positive"):
+        scs.SCS(_make_data(), _CONE, rho_x=0.0, verbose=False)
+
+
+def test_acceleration_interval_zero_raises():
+    """acceleration_interval=0 would mean AA never fires; invalid."""
+    with pytest.raises(ValueError, match="acceleration_interval must be positive"):
+        scs.SCS(_make_data(), _CONE, acceleration_interval=0, verbose=False)
 
 
 def test_max_iters_non_integer_raises():
@@ -2238,15 +2262,31 @@ def test_select_module_pops_linear_solver():
 
 
 def test_deprecated_f_cone_field():
-    """The deprecated 'f' field should be treated as zero cone."""
+    """The deprecated 'f' field should be treated as zero cone and emit
+    a DeprecationWarning that Python users can filter/capture."""
     # min c'x s.t. Ax = b  (equality via zero cone)
     A = sp.csc_matrix(np.array([[1.0], [-1.0]]))
     b = np.array([1.0, 0.0])
     c = np.array([-1.0])
     data = {"A": A, "b": b, "c": c}
     # f=1 is the old name for z=1; remaining 1 row is nonneg
-    sol = scs.solve(data, {"f": 1, "l": 1}, verbose=False)
+    with pytest.warns(DeprecationWarning, match="'f' cone field"):
+        sol = scs.solve(data, {"f": 1, "l": 1}, verbose=False)
     assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+
+
+def test_f_cone_deprecation_can_be_promoted_to_error():
+    """filterwarnings('error', DeprecationWarning) should turn the
+    'f'-cone warning into an exception the user can catch."""
+    import warnings
+    A = sp.csc_matrix(np.array([[1.0], [-1.0]]))
+    b = np.array([1.0, 0.0])
+    c = np.array([-1.0])
+    data = {"A": A, "b": b, "c": c}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(DeprecationWarning, match="'f' cone field"):
+            scs.solve(data, {"f": 1, "l": 1}, verbose=False)
 
 
 def test_f_and_z_both_set_sum():
@@ -2256,7 +2296,8 @@ def test_f_and_z_both_set_sum():
     c = np.array([-1.0])
     data = {"A": A, "b": b, "c": c}
     # f=1 + z=0 should give z=1 total; 1 remaining row is nonneg
-    sol = scs.solve(data, {"f": 1, "z": 0, "l": 1}, verbose=False)
+    with pytest.warns(DeprecationWarning):
+        sol = scs.solve(data, {"f": 1, "z": 0, "l": 1}, verbose=False)
     assert sol["info"]["status"] in ("solved", "solved_inaccurate")
 
 


### PR DESCRIPTION
## Summary

Two independent cleanups surfaced during the \`scsobject.h\` review:

### 1. \`f\` cone deprecation is now a real Python warning

The deprecation notice for the old \`'f'\` cone field was being printed via \`scs_printf\` to stdout. That meant users couldn't:
- Filter it with \`warnings.filterwarnings\`
- Capture it in logs or tests
- Promote it to an error to catch remaining usage during a migration

Switched to \`PyErr_WarnEx(PyExc_DeprecationWarning, ...)\`, so it integrates with the standard \`warnings\` machinery and \`pytest.warns\`. If the warning has been promoted to an error (e.g. \`warnings.filterwarnings(\"error\")\`), \`SCS_init\` cleans up and returns \`-1\` with the exception propagated.

### 2. Tighten settings validation

Previously the Python-side checks in \`SCS_init\` rejected only strictly negative values for several settings. Zero would slip through Python and get rejected later by SCS's own \`validate()\` (in \`scs_source/src/scs.c\`), surfacing as a generic \"ScsWork allocation error\" without naming the bad setting.

Tightened to match SCS's actual rules and corrected the messages:
- \`m\`, \`n\`, \`max_iters\`, \`acceleration_interval\`, \`rho_x\`: \`<= 0\` now rejected (was \`< 0\`).
- \`alpha\`: \`<= 0 || >= 2\` now rejected, message \"alpha must be in (0, 2)\" (was \`< 0\` with a misleading \"must be positive\").
- \`eps_abs\`, \`eps_rel\`, \`eps_infeas\`: behavior unchanged, but message corrected from \"positive\" to \"nonnegative\" (zero is accepted).

## Test plan

- [x] \`pytest test/\` — 327 passed, 66 skipped (up from 322; +5 new tests)
- New tests:
  - \`test_f_cone_deprecation_can_be_promoted_to_error\` — verifies \`filterwarnings(\"error\")\` converts the warning to a catchable exception.
  - \`test_alpha_zero_raises\`, \`test_alpha_two_raises\`, \`test_rho_x_zero_raises\`, \`test_acceleration_interval_zero_raises\` — verify each tightened bound raises \`ValueError\` at \`__init__\` with a specific message.
- Existing \`test_deprecated_f_cone_field\` and \`test_f_and_z_both_set_sum\` updated to assert the DeprecationWarning fires via \`pytest.warns\`.
- Existing \`test_max_iters_zero_raises\`, \`test_scale_zero_raises\` strengthened to match the specific error message and to trigger at \`__init__\` (no longer need the \`.solve()\` call that used to be where the error surfaced).