### PR TITLE
fix: latent Windows scs_int truncation + OOM crash in SCS_solve

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -958,27 +958,51 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
   PyThread_release_lock(self->lock);
 
   /* Build numpy arrays from the copied data (no longer under lock since
-   * these are thread-local copies) */
+   * these are thread-local copies). If PyArray_SimpleNewFromData fails
+   * (OOM), it sets a Python exception but does NOT take ownership of the
+   * buffer — so we must free the raw buffer ourselves and Py_DECREF any
+   * arrays already built (which own their buffers via NPY_ARRAY_OWNDATA). */
   veclen[0] = self->n;
   x = PyArray_SimpleNewFromData(1, veclen, scs_float_type, _x);
+  if (!x) {
+    scs_free(_x);
+    scs_free(_y);
+    scs_free(_s);
+    return NULL;
+  }
   PyArray_ENABLEFLAGS((PyArrayObject *)x, NPY_ARRAY_OWNDATA);
 
   veclen[0] = self->m;
   y = PyArray_SimpleNewFromData(1, veclen, scs_float_type, _y);
+  if (!y) {
+    scs_free(_y);
+    scs_free(_s);
+    Py_DECREF(x);
+    return NULL;
+  }
   PyArray_ENABLEFLAGS((PyArrayObject *)y, NPY_ARRAY_OWNDATA);
 
   veclen[0] = self->m;
   s = PyArray_SimpleNewFromData(1, veclen, scs_float_type, _s);
+  if (!s) {
+    scs_free(_s);
+    Py_DECREF(x);
+    Py_DECREF(y);
+    return NULL;
+  }
   PyArray_ENABLEFLAGS((PyArrayObject *)s, NPY_ARRAY_OWNDATA);
 
 /* output arguments */
+/* Use 'L' (long long) for scs_int under DLONG to match scs_int's typedef
+ * (long long); 'l' (long) would truncate to 32 bits on LLP64 Windows.
+ * Mirrors the argparse_string choice in SCS_init. */
 #ifdef DLONG
 #ifdef SFLOAT
-  char *outarg_string = "{s:l,s:l,s:l,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,"
-                        "s:f,s:f,s:f,s:f,s:f,s:l,s:l,s:s}";
+  char *outarg_string = "{s:L,s:L,s:L,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,"
+                        "s:f,s:f,s:f,s:f,s:f,s:L,s:L,s:s}";
 #else
-  char *outarg_string = "{s:l,s:l,s:l,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,"
-                        "s:d,s:d,s:d,s:d,s:d,s:l,s:l,s:s}";
+  char *outarg_string = "{s:L,s:L,s:L,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,"
+                        "s:d,s:d,s:d,s:d,s:d,s:L,s:L,s:s}";
 #endif
 #else
 #ifdef SFLOAT


### PR DESCRIPTION
## Summary

Two defensive fixes in `SCS_solve`'s result-building path in `scs/scsobject.h`:

### 1. `Py_BuildValue` format mismatch for `scs_int` under `DLONG`

The `info_dict` format string used `s:l` (long) for `scs_int` fields, but `scs_int` is typedef'd to `long long` when `DLONG` is defined (see `scs_source/include/scs_types.h`), and `meson.build` sets `-DDLONG=1` on every platform including Windows.

- **LP64 (Linux / macOS):** `long == long long == 64 bits`, so this is benign today.
- **LLP64 (Windows):** `long` is 32 bits while `long long` is 64 bits. Any `scs_int` value that exceeds 32 bits (iter counts, status codes, etc.) would silently truncate once we build wheels on Windows.

Switched to `s:L` to match `scs_int`'s actual size. This mirrors `argparse_string` in `SCS_init`, which already used `'L'` with the same rationale — added a comment cross-referencing it.

### 2. OOM crash + leak in numpy array construction

After copying `sol->{x, y, s}` into heap buffers (`_x`, `_y`, `_s`), we passed each to `PyArray_SimpleNewFromData` and unconditionally called `PyArray_ENABLEFLAGS` on the return. If the numpy call fails (OOM), it sets a Python exception but does **not** take ownership of the buffer — so:
- `PyArray_ENABLEFLAGS` would dereference `NULL` → crash.
- All three raw `scs_malloc`'d buffers would leak.
- If the first call succeeded but the second failed, ownership would be inconsistent (first buffer owned by the array, second and third still raw).

Now each return is NULL-checked: on failure we `scs_free` the still-un-owned raw buffer, `Py_DECREF` any already-constructed arrays (which own their buffers via `NPY_ARRAY_OWNDATA`), and propagate `NULL`.

## Test plan

- [x] Full test suite passes locally (`327 passed, 66 skipped`)
- [ ] CI passes on Linux / macOS / Windows across the wheel matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)