### PR TITLE
fix: guard array-type macros with PyArray_Check; XDECREF info_dict on OOM

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -127,8 +127,10 @@ static int get_pos_int_param(char *key, scs_int *v, scs_int defVal,
 /* If warm start x0 is set, copy it to input location x. Sets a Python
  * exception and returns -1 on failure. */
 static scs_int get_warm_start(scs_float *x, scs_int l, PyArrayObject *x0) {
-  if (!PyArray_ISFLOAT(x0) || PyArray_NDIM(x0) != 1 ||
-      PyArray_DIM(x0, 0) != (npy_intp)l) {
+  /* PyArray_Check first: PyArray_ISFLOAT/NDIM/DIM read numpy-specific
+   * struct fields, so on a non-array object they'd dereference garbage. */
+  if (!PyArray_Check((PyObject *)x0) || !PyArray_ISFLOAT(x0) ||
+      PyArray_NDIM(x0) != 1 || PyArray_DIM(x0, 0) != (npy_intp)l) {
     PyErr_Format(PyExc_ValueError,
                  "Warm-start must be a 1-D float array of length %ld",
                  (long)l);
@@ -587,15 +589,21 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
   /* set P if passed in */
   if (!Py_IsNone((PyObject *)Px) && !Py_IsNone((PyObject *)Pi) &&
       !Py_IsNone((PyObject *)Pp)) {
-    if (!PyArray_ISFLOAT(Px) || PyArray_NDIM(Px) != 1) {
+    /* Px/Pi/Pp are parsed with 'O' (to allow None), so we must guard
+     * PyArray_ISFLOAT/ISINTEGER with PyArray_Check — those macros read
+     * PyArrayObject-specific fields and are UB on non-array objects. */
+    if (!PyArray_Check((PyObject *)Px) || !PyArray_ISFLOAT(Px) ||
+        PyArray_NDIM(Px) != 1) {
       free_py_scs_data(d, k, stgs, &ps);
       return finish_with_type_error("Px must be a 1-D numpy array of floats");
     }
-    if (!PyArray_ISINTEGER(Pi) || PyArray_NDIM(Pi) != 1) {
+    if (!PyArray_Check((PyObject *)Pi) || !PyArray_ISINTEGER(Pi) ||
+        PyArray_NDIM(Pi) != 1) {
       free_py_scs_data(d, k, stgs, &ps);
       return finish_with_type_error("Pi must be a 1-D numpy array of ints");
     }
-    if (!PyArray_ISINTEGER(Pp) || PyArray_NDIM(Pp) != 1) {
+    if (!PyArray_Check((PyObject *)Pp) || !PyArray_ISINTEGER(Pp) ||
+        PyArray_NDIM(Pp) != 1) {
       free_py_scs_data(d, k, stgs, &ps);
       return finish_with_type_error("Pp must be a 1-D numpy array of ints");
     }
@@ -1043,11 +1051,14 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
 
   return_dict = Py_BuildValue("{s:O,s:O,s:O,s:O}", "x", x, "y", y, "s", s,
                               "info", info_dict);
-  /* give up ownership to the return dictionary */
+  /* Give up ownership to the return dictionary. x/y/s are non-NULL
+   * (NULL-checked above). info_dict can be NULL if Py_BuildValue OOM'd,
+   * in which case return_dict is also NULL (we propagate it) — use
+   * Py_XDECREF to avoid dereferencing NULL in that path. */
   Py_DECREF(x);
   Py_DECREF(y);
   Py_DECREF(s);
-  Py_DECREF(info_dict);
+  Py_XDECREF(info_dict);
 
   return return_dict;
 }
@@ -1071,7 +1082,10 @@ static PyObject *SCS_update(SCS *self, PyObject *args) {
   }
   /* set c */
   if (!Py_IsNone((PyObject *)c_in)) {
-    if (!PyArray_ISFLOAT(c_in) || PyArray_NDIM(c_in) != 1) {
+    /* Parsed with 'O' (to allow None): must PyArray_Check before using
+     * PyArray_ISFLOAT/NDIM/DIM, which are UB on non-array objects. */
+    if (!PyArray_Check((PyObject *)c_in) || !PyArray_ISFLOAT(c_in) ||
+        PyArray_NDIM(c_in) != 1) {
       return none_with_type_error(
           "c_new must be a 1-D numpy array of floats");
     }
@@ -1086,7 +1100,10 @@ static PyObject *SCS_update(SCS *self, PyObject *args) {
   }
   /* set b */
   if (!Py_IsNone((PyObject *)b_in)) {
-    if (!PyArray_ISFLOAT(b_in) || PyArray_NDIM(b_in) != 1) {
+    /* Parsed with 'O' (to allow None): must PyArray_Check before using
+     * PyArray_ISFLOAT/NDIM/DIM, which are UB on non-array objects. */
+    if (!PyArray_Check((PyObject *)b_in) || !PyArray_ISFLOAT(b_in) ||
+        PyArray_NDIM(b_in) != 1) {
       Py_XDECREF(c_contig);
       return none_with_type_error(
           "b_new must be a 1-D numpy array of floats");

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -1084,6 +1084,62 @@ def test_update_none_is_noop():
     assert_almost_equal(sol2["x"][0], sol1["x"][0], decimal=3)
 
 
+@pytest.mark.parametrize("bad", ["not_an_array", 42, [1.0, 2.0], {"x": 1}])
+def test_update_b_non_array_raises_typeerror(bad):
+    """Passing a non-None, non-array object for b must raise TypeError, not
+    crash. PyArray_ISFLOAT/NDIM are UB on non-array objects."""
+    solver = scs.SCS(_make_data(), _CONE, verbose=False)
+    with pytest.raises(TypeError, match="numpy array"):
+        solver.update(b=bad)
+
+
+@pytest.mark.parametrize("bad", ["not_an_array", 42, [1.0], {"x": 1}])
+def test_update_c_non_array_raises_typeerror(bad):
+    solver = scs.SCS(_make_data(), _CONE, verbose=False)
+    with pytest.raises(TypeError, match="numpy array"):
+        solver.update(c=bad)
+
+
+@pytest.mark.parametrize(
+    "kw", ["x", "y", "s"]
+)
+@pytest.mark.parametrize("bad", ["not_an_array", 42, [1.0]])
+def test_warm_start_non_array_raises(kw, bad):
+    """Non-None, non-array warm-start arg must raise, not crash."""
+    solver = scs.SCS(_make_data(), _CONE, verbose=False)
+    solver.solve()
+    with pytest.raises((TypeError, ValueError)):
+        solver.solve(warm_start=True, **{kw: bad})
+
+
+@pytest.mark.parametrize("slot", ["Px", "Pi", "Pp"])
+def test_raw_c_init_non_array_P_raises(slot):
+    """Bypass the Python wrapper and hand _scs.SCS a non-None, non-array
+    object for Px/Pi/Pp. Must raise TypeError, not crash."""
+    from scs import _scs_direct
+
+    Adata = np.array([1.0, -1.0])
+    Aindices = np.array([0, 1], dtype=np.int64)
+    Acolptr = np.array([0, 2], dtype=np.int64)
+    b = np.array([1.0, 0.0])
+    c = np.array([-1.0])
+    P = {"Px": None, "Pi": None, "Pp": None}
+    P[slot] = "not_an_array"
+    # Give the other two valid 1-D arrays so only `slot` is bad
+    if slot != "Px":
+        P["Px"] = np.array([1.0])
+    if slot != "Pi":
+        P["Pi"] = np.array([0], dtype=np.int64)
+    if slot != "Pp":
+        P["Pp"] = np.array([0, 1], dtype=np.int64)
+    with pytest.raises(TypeError, match="numpy array"):
+        _scs_direct.SCS(
+            (2, 1), Adata, Aindices, Acolptr,
+            P["Px"], P["Pi"], P["Pp"],
+            b, c, {"l": 2}, verbose=False,
+        )
+
+
 # ===========================================================================
 # 25. Sequential updates: each solve reflects the new problem
 # ===========================================================================


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes in `scs/scsobject.h`.

### 1. `PyArray_ISFLOAT` / `PyArray_ISINTEGER` called without `PyArray_Check` guard

These macros expand to `PyArray_TYPE(o)` → cast to `PyArrayObject_fields*` and read `descr->type_num`. On a non-array object (string, int, list, dict), that dereferences garbage — UB, likely crash.

Three sites parse their input with `'O'` (to allow `None`) and then call `PyArray_ISFLOAT`/`ISINTEGER` after only a `Py_IsNone` check:

- `SCS_init`: `Px`, `Pi`, `Pp`
- `SCS_update`: `b_in`, `c_in`
- `get_warm_start`: `x0` (invoked from `SCS_solve` for `warm_x` / `warm_y` / `warm_s`)

The Python wrapper in `scs/py/__init__.py` sanitizes most of these for normal users, but the raw C entry points (`_scs_direct.SCS(...)`, `solver.solve(x=...)`, `solver.update(b=...)`) are still reachable and must not crash on bad input. Added `PyArray_Check` in front of each `ISFLOAT`/`ISINTEGER` call, folded into the existing `TypeError` path.

### 2. `Py_DECREF(info_dict)` on NULL after OOM

At the end of `SCS_solve`:

```c
info_dict = Py_BuildValue(outarg_string, ...);   // can return NULL on OOM
return_dict = Py_BuildValue("{s:O,s:O,s:O,s:O}", ..., "info", info_dict);
Py_DECREF(x);
Py_DECREF(y);
Py_DECREF(s);
Py_DECREF(info_dict);   // <-- UB if info_dict is NULL
```

`Py_DECREF(NULL)` is explicitly UB per the CPython docs. Switched to `Py_XDECREF(info_dict)`. `x` / `y` / `s` stay as `Py_DECREF` — they were NULL-checked upstream in #200.

## Test plan

- [x] 20 new parametrized tests covering non-array inputs to `update(b/c)`, `solve(x/y/s)` warm-start, and the raw-C `_scs_direct.SCS` init for Px/Pi/Pp.
- [x] Full suite locally: `347 passed, 66 skipped` (was 327 before).
- [ ] CI on Linux / macOS / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)