### PR TITLE
fix: flatten sparse b/c to 1-D (todense returns np.matrix)

### DIFF
--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -126,11 +126,13 @@ class SCS(object):
       )
       A = A.tocsc()
 
+    # .todense() returns a 2-D np.matrix; the C layer requires ndim==1.
+    # Flatten to a 1-D ndarray so a sparse b or c is actually accepted.
     if sparse.issparse(b):
-      b = b.todense()
+      b = np.asarray(b.todense()).ravel()
 
     if sparse.issparse(c):
-      c = c.todense()
+      c = np.asarray(c.todense()).ravel()
 
     m = len(b)
     n = len(c)

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -154,24 +154,38 @@ def test_csr_P_warns_and_solves():
 # ===========================================================================
 # 3. Sparse b / c behavior
 # ===========================================================================
-# The Python layer calls b.todense() / c.todense() which returns a 2-D
-# numpy.matrix; the C extension then rejects it because it expects a 1-D
-# array.  These tests document that current behaviour and will need updating
-# if the conversion is fixed to call np.asarray(...).flatten() instead.
+# Sparse b / c are flattened to 1-D dense arrays by the Python wrapper and
+# should solve identically to the dense version.
 
 
-def test_sparse_b_raises_valueerror():
-    """Sparse b is converted to a 2-D matrix that the C layer rejects."""
+def test_sparse_b_solves():
+    """Sparse b is flattened to 1-D and solves correctly."""
     b_sparse = sp.csc_matrix(_b.reshape(-1, 1))
-    with pytest.raises((ValueError, TypeError)):
-        scs.SCS({"A": _A, "b": b_sparse, "c": _c}, _CONE, verbose=False)
+    solver = scs.SCS({"A": _A, "b": b_sparse, "c": _c}, _CONE, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+    assert_almost_equal(sol["x"][0], 1.0, decimal=2)
 
 
-def test_sparse_c_raises_valueerror():
-    """Sparse c is converted to a 2-D matrix that the C layer rejects."""
+def test_sparse_c_solves():
+    """Sparse c is flattened to 1-D and solves correctly."""
     c_sparse = sp.csc_matrix(_c.reshape(-1, 1))
-    with pytest.raises((ValueError, TypeError)):
-        scs.SCS({"A": _A, "b": _b, "c": c_sparse}, _CONE, verbose=False)
+    solver = scs.SCS({"A": _A, "b": _b, "c": c_sparse}, _CONE, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+    assert_almost_equal(sol["x"][0], 1.0, decimal=2)
+
+
+def test_sparse_b_and_c_solves():
+    """Both b and c sparse still solves correctly."""
+    b_sparse = sp.csc_matrix(_b.reshape(-1, 1))
+    c_sparse = sp.csc_matrix(_c.reshape(-1, 1))
+    solver = scs.SCS(
+        {"A": _A, "b": b_sparse, "c": c_sparse}, _CONE, verbose=False
+    )
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+    assert_almost_equal(sol["x"][0], 1.0, decimal=2)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

`scs/py/__init__.py` had a latent bug in its sparse-b/c conversion:

```python
if sparse.issparse(b):
    b = b.todense()   # → numpy.matrix, ndim == 2
```

`scipy.sparse.csc_matrix.todense()` returns a `numpy.matrix` whose `ndim` is always 2. The C layer requires `ndim == 1` for `b` and `c`, so any user passing a sparse `b` or `c` hit:

```
TypeError: b must be a 1-D numpy array of floats
```

(reproduced locally). The branch was effectively dead.

Fix: `np.asarray(x.todense()).ravel()` to produce a 1-D `ndarray`.

## Tests

Two existing tests in `test_scs_coverage.py` explicitly documented the broken behavior:

```
# These tests document that current behaviour and will need updating
# if the conversion is fixed to call np.asarray(...).flatten() instead.
```

Flipped them to assert the sparse path now solves correctly, and added `test_sparse_b_and_c_solves` covering both sparse together.

## Test plan

- [x] Full suite locally: `328 passed, 66 skipped`.
- [x] `test_sparse_b_solves`, `test_sparse_c_solves`, `test_sparse_b_and_c_solves` pass.
- [ ] CI.

Independent of #201 — touches only `scs/py/__init__.py` + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)