### PR TITLE
fix: don't mutate caller's sparse A/P indices in place

### DIFF
--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -135,8 +135,11 @@ class SCS(object):
     m = len(b)
     n = len(c)
 
+    # sorted_indices() returns a new matrix; sort_indices() would mutate
+    # the caller's A in place (surprising, and a data race under the
+    # free-threaded build if another thread reads the same matrix).
     if not A.has_sorted_indices:
-      A.sort_indices()
+      A = A.sorted_indices()
     Adata, Aindices, Acolptr = A.data, A.indices, A.indptr
     if A.shape != (m, n):
       raise ValueError("A shape not compatible with b,c")
@@ -155,8 +158,9 @@ class SCS(object):
               "matrix; may take a while."
           )
           P = P.tocsc()
+        # sorted_indices() returns a new matrix; see A above.
         if not P.has_sorted_indices:
-          P.sort_indices()
+          P = P.sorted_indices()
         # extract upper triangular component only
         if _has_lower_tri(P):
           P = sparse.triu(P, format="csc")

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -174,6 +174,48 @@ def test_sparse_c_raises_valueerror():
         scs.SCS({"A": _A, "b": _b, "c": c_sparse}, _CONE, verbose=False)
 
 
+def test_unsorted_A_indices_are_not_mutated():
+    """Passing A with unsorted CSC indices must not mutate the caller's
+    object. Previously we called A.sort_indices() in place."""
+    data = np.array([1.0, -1.0])
+    indices = np.array([1, 0], dtype=np.int64)  # unsorted within column
+    indptr = np.array([0, 2], dtype=np.int64)
+    A = sp.csc_matrix((data, indices, indptr), shape=(2, 1))
+    assert not A.has_sorted_indices
+    original_indices = A.indices.copy()
+    solver = scs.SCS(
+        {"A": A, "b": _b, "c": _c}, _CONE, verbose=False
+    )
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+    # Caller's A must be untouched
+    assert not A.has_sorted_indices
+    assert np.array_equal(A.indices, original_indices)
+
+
+def test_unsorted_P_indices_are_not_mutated():
+    """Passing P with unsorted CSC indices must not mutate the caller's P."""
+    # 1x1 P so the only concern is indices ordering; use 2x2 so we can
+    # actually have unsorted within a column.
+    # n must equal len(c), so build a 2-variable problem.
+    A2 = sp.csc_matrix(np.array([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0],
+                                  [0.0, -1.0]]))
+    b2 = np.array([1.0, 0.0, 1.0, 0.0])
+    c2 = np.array([-1.0, -1.0])
+    # P with unsorted indices within col 0
+    P_data = np.array([2.0, 1.0])
+    P_idx = np.array([1, 0], dtype=np.int64)  # col 0: rows (1, 0) — unsorted
+    P_ptr = np.array([0, 2, 2], dtype=np.int64)
+    P = sp.csc_matrix((P_data, P_idx, P_ptr), shape=(2, 2))
+    assert not P.has_sorted_indices
+    original_P_indices = P.indices.copy()
+    scs.SCS(
+        {"A": A2, "b": b2, "c": c2, "P": P}, {"l": 4}, verbose=False
+    ).solve()
+    assert not P.has_sorted_indices
+    assert np.array_equal(P.indices, original_P_indices)
+
+
 # ===========================================================================
 # 4. P-matrix handling
 # ===========================================================================


### PR DESCRIPTION
## Summary

`scs/py/__init__.py` called `A.sort_indices()` / `P.sort_indices()` when the caller's CSC matrix had unsorted column indices. Both are **in-place** mutations of a user-owned object — surprising on its own, and under the free-threaded build a concurrent reader of the same matrix races against our sort.

Reproduced: passing a CSC matrix with unsorted indices flips `A.has_sorted_indices` from `False` → `True` and reorders `A.indices` under the caller's feet.

Fix: use `A.sorted_indices()` / `P.sorted_indices()` (return a new matrix) instead. The rest of `__init__` binds `A = A.sorted_indices()` locally, so the caller's object is untouched.

## Tests

- Existing "unsorted indices still solve correctly" tests still pass.
- Added `test_unsorted_A_indices_are_not_mutated` and `test_unsorted_P_indices_are_not_mutated` — both snapshot `indices` and `has_sorted_indices` before the call and assert equality after.

Full suite: `329 passed, 66 skipped`.

Independent of #201 / #202 — touches only `scs/py/__init__.py` (disjoint edits from #202) + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)