### PR TITLE
fix: reject negative entries in numpy-array cone dims

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -206,6 +206,18 @@ static int get_cone_arr_dim(char *key, scs_int **varr, scs_int *vsize,
       }
       memcpy(q, (scs_int *)PyArray_DATA(px0), n * sizeof(scs_int));
       Py_DECREF(px0);
+      /* Match the list/scalar branches (which use parse_pos_scs_int):
+       * cone dimensions must be non-negative. Without this check a
+       * user-supplied numpy array with negative entries would slip
+       * through Python-side validation and surface later as a generic
+       * "ScsWork allocation error!" from SCS core. */
+      for (i = 0; i < n; ++i) {
+        if (q[i] < 0) {
+          scs_free(q);
+          Py_DECREF(obj);
+          return printErr(key);
+        }
+      }
     } else {
       Py_DECREF(obj);
       return printErr(key);

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2344,6 +2344,47 @@ def test_cone_q_as_single_int():
 
 
 # ===========================================================================
+# Cone-field validation parity across list / scalar / numpy-array branches
+# ===========================================================================
+# The list branch uses parse_pos_scs_int (rejects negatives). The scalar
+# branch uses get_pos_int_param (rejects negatives). The numpy-array branch
+# previously memcpy'd straight into scs_int*, letting negatives slip
+# through Python-side validation and surface as a misleading
+# "ScsWork allocation error!" from SCS core.
+
+
+@pytest.mark.parametrize(
+    "bad_q",
+    [
+        [-1],
+        -1,
+        np.array([-1], dtype=np.int64),
+        np.array([2, -3], dtype=np.int64),
+    ],
+    ids=["list", "scalar", "np_single_neg", "np_mixed_neg"],
+)
+def test_cone_q_negative_rejected(bad_q):
+    A = sp.csc_matrix(np.eye(3))
+    b = np.array([0.0, 1.0, 1.0])
+    c = np.array([-1.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="Invalid value for cone field 'q'"):
+        scs.SCS({"A": A, "b": b, "c": c}, {"q": bad_q}, verbose=False)
+
+
+@pytest.mark.parametrize(
+    "bad_s",
+    [[-1], -1, np.array([-1], dtype=np.int64)],
+    ids=["list", "scalar", "np"],
+)
+def test_cone_s_negative_rejected(bad_s):
+    A = sp.csc_matrix(np.eye(3))
+    b = np.array([0.0, 1.0, 1.0])
+    c = np.array([-1.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="Invalid value for cone field 's'"):
+        scs.SCS({"A": A, "b": b, "c": c}, {"s": bad_s}, verbose=False)
+
+
+# ===========================================================================
 # 65. Warm-start with wrong-dimension vectors
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

`get_cone_arr_dim` in `scs/scsobject.h` handles three input shapes for integer cone fields (`q`, `s`, `cs`, etc.):

- **Python list** → `parse_pos_scs_int` (rejects negatives)
- **bare scalar** → `get_pos_int_param` → `parse_pos_scs_int` (rejects negatives)
- **numpy array** → straight `memcpy` into `scs_int *` (no sign check)

The array branch thus let negatives slip past Python-side validation. They'd then surface as a misleading `"ScsWork allocation error!"` ValueError, with SCS core printing `"soc cone dimension error"` to stderr before failing workspace init.

Reproduced locally:

```
>>> scs.SCS(..., {"q": [-1]}, ...)
ValueError: Invalid value for cone field 'q'
>>> scs.SCS(..., {"q": -1}, ...)
ValueError: Invalid value for cone field 'q'
>>> scs.SCS(..., {"q": np.array([-1])}, ...)
soc cone dimension error                          # <-- to stderr, from SCS core
cone validation error
ValueError: ScsWork allocation error!              # <-- wrong & generic
```

## Fix

After the `memcpy`, walk the copied entries and `printErr(key)` on any negative — same error shape the list/scalar branches produce.

## Tests

Added parametrized tests covering list, scalar, and numpy-array inputs for cone fields `q` and `s`, all asserting:

```
ValueError: Invalid value for cone field '<key>'
```

Full suite locally: `334 passed, 66 skipped`.

Independent of #201 / #202 / #203 — touches only `scs/scsobject.h` (disjoint from #201) and `test/test_scs_coverage.py` (disjoint from others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)