### PR TITLE
fix: reject NaN/+inf in numeric settings validation

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -793,10 +793,14 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
                              ? (scs_int)PyObject_IsTrue(adaptive_scale)
                              : ADAPTIVE_SCALE;
 
-  /* Ranges below match SCS's own validate() in scs_source/src/scs.c.
-   * Duplicated here so users get a Python exception naming the offending
-   * setting, rather than SCS's scs_printf + generic "ScsWork allocation
-   * error" fallback. */
+  /* Ranges below match SCS's own validate() in scs_source/src/scs.c, plus
+   * explicit isnan/isfinite guards that SCS's validate() lacks. Without
+   * those, NaN values slip through every `x <= 0` / `x < 0` / `x >= 2`
+   * check (IEEE NaN comparisons always return false) and the solver runs
+   * to completion producing NaN iterates; +inf on scale or rho_x either
+   * crashes the linear-system factorization with a misleading "ScsWork
+   * allocation error!" or silently produces NaN. Better to raise a
+   * Python exception naming the offending setting up front. */
   if (stgs->max_iters <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("max_iters must be positive");
@@ -808,33 +812,36 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_interval must be positive");
   }
-  if (stgs->scale <= 0) {
+  if (!isfinite((double)stgs->scale) || stgs->scale <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("scale must be positive");
+    return finish_with_error("scale must be a positive finite number");
   }
-  if (stgs->time_limit_secs < 0) {
+  /* time_limit_secs: 0 disables the limit, +inf is equivalent, both allowed. */
+  if (isnan((double)stgs->time_limit_secs) || stgs->time_limit_secs < 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("time_limit_secs must be nonnegative");
   }
-  if (stgs->eps_abs < 0) {
+  /* eps_*: +inf is allowed (effectively disables that stopping criterion);
+   * NaN is not — it would make every tolerance comparison false. */
+  if (isnan((double)stgs->eps_abs) || stgs->eps_abs < 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("eps_abs must be nonnegative");
   }
-  if (stgs->eps_rel < 0) {
+  if (isnan((double)stgs->eps_rel) || stgs->eps_rel < 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("eps_rel must be nonnegative");
   }
-  if (stgs->eps_infeas < 0) {
+  if (isnan((double)stgs->eps_infeas) || stgs->eps_infeas < 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("eps_infeas must be nonnegative");
   }
-  if (stgs->alpha <= 0 || stgs->alpha >= 2) {
+  if (!isfinite((double)stgs->alpha) || stgs->alpha <= 0 || stgs->alpha >= 2) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("alpha must be in (0, 2)");
   }
-  if (stgs->rho_x <= 0) {
+  if (!isfinite((double)stgs->rho_x) || stgs->rho_x <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("rho_x must be positive");
+    return finish_with_error("rho_x must be a positive finite number");
   }
   stgs->warm_start = WARM_START; /* False by default */
 

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -1075,7 +1075,7 @@ def test_max_iters_zero_raises():
 
 def test_scale_zero_raises():
     """scale=0 is invalid and should raise ValueError at __init__."""
-    with pytest.raises(ValueError, match="scale must be positive"):
+    with pytest.raises(ValueError, match="scale must be"):
         scs.SCS(_make_data(), _CONE, scale=0.0, verbose=False)
 
 
@@ -1093,7 +1093,7 @@ def test_alpha_two_raises():
 
 def test_rho_x_zero_raises():
     """rho_x=0 is invalid — the primal regularizer must be positive."""
-    with pytest.raises(ValueError, match="rho_x must be positive"):
+    with pytest.raises(ValueError, match="rho_x must be"):
         scs.SCS(_make_data(), _CONE, rho_x=0.0, verbose=False)
 
 
@@ -2327,6 +2327,42 @@ def test_negative_acceleration_interval_raises():
 def test_negative_max_iters_raises():
     with pytest.raises(ValueError, match="max_iters"):
         scs.SCS(_make_data(), _CONE, max_iters=-10, verbose=False)
+
+
+# NaN must be rejected on every float setting. Without explicit isnan
+# guards, `x <= 0` / `x < 0` / `x >= 2` all return false for NaN, the
+# setting slips through and the solver produces NaN iterates.
+@pytest.mark.parametrize(
+    "field",
+    ["scale", "rho_x", "alpha", "eps_abs", "eps_rel", "eps_infeas",
+     "time_limit_secs"],
+)
+def test_nan_setting_rejected(field):
+    with pytest.raises(ValueError, match=field):
+        scs.SCS(_make_data(), _CONE, verbose=False,
+                **{field: float("nan")})
+
+
+# +inf on scale / rho_x / alpha must be rejected (they must be finite).
+# scale=+inf otherwise triggers a misleading "ScsWork allocation error!"
+# from the linear-solver factorization; rho_x=+inf produces NaN iterates.
+@pytest.mark.parametrize("field", ["scale", "rho_x", "alpha"])
+def test_posinf_setting_rejected(field):
+    with pytest.raises(ValueError, match=field):
+        scs.SCS(_make_data(), _CONE, verbose=False,
+                **{field: float("inf")})
+
+
+# +inf on eps_* and time_limit_secs is semantically meaningful (disables
+# that stopping criterion / time limit) and must still be accepted.
+@pytest.mark.parametrize(
+    "field", ["eps_abs", "eps_rel", "eps_infeas", "time_limit_secs"]
+)
+def test_posinf_setting_accepted(field):
+    solver = scs.SCS(_make_data(), _CONE, verbose=False, max_iters=50,
+                     **{field: float("inf")})
+    sol = solver.solve()
+    assert sol["info"]["status_val"] != 0  # some terminal status reached
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- IEEE NaN comparisons always return false, so `x <= 0` / `x < 0` / `x >= 2` let NaN slip through every numeric setting in `SCS_init`. The solver then runs to completion producing NaN iterates with no error surfaced. SCS core's own `validate()` has the same gap.
- `scale=+inf` additionally triggers a misleading "ScsWork allocation error!" from the linear-system factorization; `rho_x=+inf` silently produces NaN iterates.
- Add explicit `isnan`/`isfinite` guards in the validation block. `scale`, `rho_x`, `alpha` must now be finite; `eps_*` and `time_limit_secs` reject NaN but still accept `+inf` (semantically meaningful — disables that stopping criterion / time limit).

## Repro (before)
```python
sol = scs.solve(data, {"q": [], "l": 2}, scale=float("nan"))
# -> runs to "max_iters reached", x=[nan]
sol = scs.solve(data, {"q": [], "l": 2}, scale=float("inf"))
# -> ValueError: ScsWork allocation error!  (misleading)
```

## After
```
ValueError: scale must be a positive finite number
```

## Test plan
- [x] 11 new parametrized tests covering NaN on all 7 float settings, +inf rejection on `scale`/`rho_x`/`alpha`, +inf acceptance on `eps_*`/`time_limit_secs`
- [x] Existing `test_scale_zero_raises` / `test_rho_x_zero_raises` regex relaxed to accommodate the updated error string
- [x] Full suite green (371 passed, 66 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)