### PR TITLE
docs: update README for LinearSolver rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ solver = scs.SCS(data, cone)
 solver = scs.SCS(data, cone, linear_solver=scs.LinearSolver.QDLDL)
 ```
 
-Available values: `AUTO`, `QDLDL`, `INDIRECT`, `MKL`, `ACCELERATE`, `DENSE`,
-`GPU`, `CUDSS`.
+Available values: `AUTO`, `QDLDL`, `CPU_INDIRECT`, `MKL`, `ACCELERATE`,
+`CPU_DENSE`, `GPU_INDIRECT`, `CUDSS`.
 
 The pre-built wheels (`pip install scs`) include MKL on x86_64 Linux and
 Windows, and Apple Accelerate on macOS. When installing from source, additional


### PR DESCRIPTION
## Summary
Follow-up to #206. The enum member list in the README still referred to the old names `INDIRECT` / `GPU` / `DENSE`; updated to `CPU_INDIRECT` / `GPU_INDIRECT` / `CPU_DENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)