### PR TITLE
Expose Anderson acceleration tuning settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ print(sol["info"]["aa_stats"])  # Anderson acceleration diagnostics
 print(sol["x"])               # primal solution
 ```
 
+### Anderson acceleration tuning
+
+SCS applies Anderson acceleration (AA) on top of ADMM. The defaults work
+well for most problems, but the following settings can be tuned:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `acceleration_lookback` | `10` | AA memory size; `0` disables AA. |
+| `acceleration_interval` | `10` | Apply AA every N ADMM iterations. |
+| `acceleration_type_1` | `1` | `1` = type-I AA, `0` = type-II AA. |
+| `acceleration_regularization` | `1e-8` | Tikhonov regularization for the AA least-squares solve. Tuned for type-I; type-II typically prefers `1e-12`. |
+| `acceleration_relaxation` | `1.0` | Relaxation factor in `[0, 2]`; `1.0` is vanilla AA. |
+
+```python
+# Type-II AA with tighter regularization
+solver = scs.SCS(data, cone,
+                 acceleration_type_1=0,
+                 acceleration_regularization=1e-12)
+```
+
+See the [acceleration docs](https://www.cvxgrp.org/scs/algorithm/acceleration.html)
+for the underlying algorithm.
+
 ### Cone types
 
 The `cone` dict supports the following keys:

--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -487,6 +487,9 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
                     "time_limit_secs",
                     "acceleration_lookback",
                     "acceleration_interval",
+                    "acceleration_type_1",
+                    "acceleration_regularization",
+                    "acceleration_relaxation",
                     "write_data_filename",
                     "log_csv_filename",
                     NULL};
@@ -496,15 +499,15 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
    on Windows where sizeof(long) < sizeof(long long) (LLP64 model). */
 #ifdef DLONG
 #ifdef SFLOAT
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LfffffffLLzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LfffffffLLLffzz";
 #else
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LdddddddLLzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LdddddddLLLddzz";
 #endif
 #else
 #ifdef SFLOAT
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!ifffffffiizz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!ifffffffiiiffzz";
 #else
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!idddddddiizz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!idddddddiiiddzz";
 #endif
 #endif
 
@@ -541,6 +544,9 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
           &(stgs->time_limit_secs),
           &(stgs->acceleration_lookback),
           &(stgs->acceleration_interval),
+          &(stgs->acceleration_type_1),
+          &(stgs->acceleration_regularization),
+          &(stgs->acceleration_relaxation),
           &(stgs->write_data_filename),
           &(stgs->log_csv_filename))) {
     /* PyArg_ParseTupleAndKeywords already set an informative TypeError
@@ -805,12 +811,29 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("max_iters must be positive");
   }
-  /* acceleration_lookback: positive selects type-I AA, negative selects
-   * type-II; the magnitude is used as the memory size. Zero disables
-   * acceleration. Passed through unchanged — see scs.c's aa_init call. */
+  /* acceleration_lookback: nonnegative memory size for AA. 0 disables
+   * acceleration; the type (I or II) is selected by acceleration_type_1. */
+  if (stgs->acceleration_lookback < 0) {
+    free_py_scs_data(d, k, stgs, &ps);
+    return finish_with_error(
+        "acceleration_lookback must be nonnegative "
+        "(use acceleration_type_1=0 for type-II AA)");
+  }
   if (stgs->acceleration_interval <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_interval must be positive");
+  }
+  if (!isfinite((double)stgs->acceleration_regularization) ||
+      stgs->acceleration_regularization < 0) {
+    free_py_scs_data(d, k, stgs, &ps);
+    return finish_with_error(
+        "acceleration_regularization must be a nonnegative finite number");
+  }
+  if (!isfinite((double)stgs->acceleration_relaxation) ||
+      stgs->acceleration_relaxation < 0 ||
+      stgs->acceleration_relaxation > 2) {
+    free_py_scs_data(d, k, stgs, &ps);
+    return finish_with_error("acceleration_relaxation must be in [0, 2]");
   }
   if (!isfinite((double)stgs->scale) || stgs->scale <= 0) {
     free_py_scs_data(d, k, stgs, &ps);

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2722,14 +2722,59 @@ def test_cold_start_after_warm():
 
 
 # ===========================================================================
-# 72. Acceleration lookback negative (type-I AA hack)
+# 72. Anderson acceleration tuning settings
 # ===========================================================================
 
 
-def test_negative_acceleration_lookback():
-    """Negative acceleration_lookback triggers type-I AA (intentional hack)."""
+def test_negative_acceleration_lookback_rejected():
+    """Negative lookback used to mean type-II; now it must be rejected."""
+    with pytest.raises(ValueError, match="acceleration_lookback must be nonnegative"):
+        scs.SCS(_make_data(), _CONE,
+                acceleration_lookback=-10, verbose=False)
+
+
+def test_acceleration_type_1_explicit():
+    """acceleration_type_1=0 selects type-II AA; should still solve."""
+    solver = scs.SCS(
+        _make_data(), _CONE,
+        acceleration_lookback=10,
+        acceleration_type_1=0,
+        acceleration_regularization=1e-12,
+        verbose=False,
+    )
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+
+
+@pytest.mark.parametrize("relaxation", [0.0, 0.5, 1.0, 1.5, 2.0])
+def test_acceleration_relaxation_in_range(relaxation):
+    solver = scs.SCS(
+        _make_data(), _CONE,
+        acceleration_relaxation=relaxation,
+        verbose=False,
+    )
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+
+
+@pytest.mark.parametrize("bad", [-0.1, 2.1, float("nan"), float("inf")])
+def test_acceleration_relaxation_out_of_range_rejected(bad):
+    with pytest.raises(ValueError, match="acceleration_relaxation"):
+        scs.SCS(_make_data(), _CONE,
+                acceleration_relaxation=bad, verbose=False)
+
+
+@pytest.mark.parametrize("bad", [-1e-12, float("nan"), float("inf")])
+def test_acceleration_regularization_invalid_rejected(bad):
+    with pytest.raises(ValueError, match="acceleration_regularization"):
+        scs.SCS(_make_data(), _CONE,
+                acceleration_regularization=bad, verbose=False)
+
+
+def test_acceleration_regularization_zero_allowed():
+    """Zero regularization is permitted (matches aa.h: 0 disables it)."""
     solver = scs.SCS(_make_data(), _CONE,
-                     acceleration_lookback=-10, verbose=False)
+                     acceleration_regularization=0.0, verbose=False)
     sol = solver.solve()
     assert sol["info"]["status"] in ("solved", "solved_inaccurate")
 


### PR DESCRIPTION
## Summary
- Plumbs three new settings through to the SCS C library: \`acceleration_type_1\`, \`acceleration_regularization\`, \`acceleration_relaxation\`.
- Replaces the negative-\`acceleration_lookback\` hack (which used the sign to flip type-I vs type-II AA). The lookback must now be nonnegative; the type is selected explicitly.
- Validation in \`scsobject.h\` rejects negative lookback (with a hint pointing users at \`acceleration_type_1=0\`), non-finite or out-of-range \`relaxation\` (must be in \`[0, 2]\`) and non-finite/negative \`regularization\`.
- Bumps the \`scs_source\` submodule to the matching commit on \`expose-aa-settings\`. This pin is on a branch — once cvxgrp/scs#387 lands I'll re-pin to the merge SHA.

Companion PR: https://github.com/cvxgrp/scs/pull/387

## Test plan
- [x] Local: \`python -m pytest test/\` (372 tests, plus dense suite) all pass.
- [x] Manual: smoke-tested defaults, type-II with reduced regularization, custom relaxation, and the three rejection paths.
- [ ] CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)