### PR TITLE
Prefer QDLDL over Apple Accelerate in AUTO on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install .
 
 SCS supports several linear solver backends. The default is `AUTO`, which
 selects the best available solver for the platform:
-- **macOS**: Apple Accelerate if available, otherwise QDLDL
+- **macOS**: QDLDL (Apple Accelerate is available via `LinearSolver.ACCELERATE`)
 - **Linux / Windows**: MKL Pardiso if available, otherwise QDLDL
 
 ```python

--- a/scs/py/__init__.py
+++ b/scs/py/__init__.py
@@ -45,15 +45,12 @@ def _load_module(name):
 def _resolve_auto():
   """Auto-detect the best available direct solver for this platform."""
   if sys.platform == "darwin":
-    try:
-      return _load_module("_scs_accelerate")
-    except ImportError:
-      pass
-  else:
-    try:
-      return _load_module("_scs_mkl")
-    except ImportError:
-      pass
+    # Prefer the bundled QDLDL on macOS over Apple Accelerate.
+    return _scs_direct
+  try:
+    return _load_module("_scs_mkl")
+  except ImportError:
+    pass
   return _scs_direct
 
 

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -3249,23 +3249,20 @@ def test_resolve_auto_falls_back_to_qdldl():
 
 
 @pytest.mark.thread_unsafe(reason="patches module-level scs._load_module / scs.sys")
-def test_resolve_auto_darwin_tries_accelerate():
-    """On macOS, AUTO should try _scs_accelerate first."""
-    from unittest.mock import patch, MagicMock
-    from scs import _resolve_auto
+def test_resolve_auto_darwin_prefers_qdldl():
+    """On macOS, AUTO should return QDLDL without attempting Accelerate."""
+    from unittest.mock import patch
+    from scs import _resolve_auto, _scs_direct
 
-    fake_accel = MagicMock()
-
-    def mock_load(name):
-        if name == "_scs_accelerate":
-            return fake_accel
+    def fail_import(name):
         raise ImportError(f"mocked: {name}")
 
     with patch("scs.sys") as mock_sys:
         mock_sys.platform = "darwin"
-        with patch("scs._load_module", side_effect=mock_load):
+        with patch("scs._load_module", side_effect=fail_import) as mock_load:
             module = _resolve_auto()
-    assert module is fake_accel
+    assert module is _scs_direct
+    mock_load.assert_not_called()
 
 
 @pytest.mark.thread_unsafe(reason="patches module-level scs._load_module / scs.sys")
@@ -3306,22 +3303,6 @@ def test_resolve_auto_windows_tries_mkl():
         with patch("scs._load_module", side_effect=mock_load):
             module = _resolve_auto()
     assert module is fake_mkl
-
-
-@pytest.mark.thread_unsafe(reason="patches module-level scs._load_module / scs.sys")
-def test_resolve_auto_darwin_fallback_when_no_accelerate():
-    """On macOS, AUTO should fall back to QDLDL when Accelerate is missing."""
-    from unittest.mock import patch
-    from scs import _resolve_auto, _scs_direct
-
-    def fail_import(name):
-        raise ImportError(f"mocked: {name}")
-
-    with patch("scs.sys") as mock_sys:
-        mock_sys.platform = "darwin"
-        with patch("scs._load_module", side_effect=fail_import):
-            module = _resolve_auto()
-    assert module is _scs_direct
 
 
 @pytest.mark.thread_unsafe(reason="patches module-level scs._load_module / scs.sys")


### PR DESCRIPTION
## Summary
- Swap the macOS branch of `_resolve_auto` to return the bundled QDLDL (`_scs_direct`) instead of trying `_scs_accelerate` first.
- Accelerate is still available explicitly via `LinearSolver.ACCELERATE` — only the AUTO default changes.
- Update the macOS README bullet and consolidate the darwin auto-detect tests in `test_scs_coverage.py` to assert the new behavior (QDLDL is returned without attempting `_scs_accelerate`).

## Test plan
- [ ] `pytest test/test_scs_coverage.py -k "linear_solver or resolve_auto"`
- [ ] `python -c "import scs; print(scs._resolve_auto())"` on macOS returns `_scs_direct`
- [ ] `LinearSolver.ACCELERATE` continues to work when the wheel includes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)