### PR TITLE
Fix PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ scs-python
 
 [![Build Status](https://github.com/bodono/scs-python/actions/workflows/build.yml/badge.svg)](https://github.com/bodono/scs-python/actions/workflows/build.yml)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen?logo=read-the-docs&style=flat)](https://www.cvxgrp.org/scs/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/scs.svg?label=PyPI%20downloads&cacheSeconds=86400)](https://pypistats.org/packages/scs)
+[![PyPI Downloads](https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads)](https://pepy.tech/projects/scs)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scs.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/scs)
 
 Python interface for [SCS](https://github.com/cvxgrp/scs) 3.0.0 and higher.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ scs-python
 
 [![Build Status](https://github.com/bodono/scs-python/actions/workflows/build.yml/badge.svg)](https://github.com/bodono/scs-python/actions/workflows/build.yml)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen?logo=read-the-docs&style=flat)](https://www.cvxgrp.org/scs/)
-[![PyPI Downloads](https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads)](https://pepy.tech/projects/scs)
+[![PyPI Downloads](https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads%2Fmonth)](https://pepy.tech/projects/scs)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scs.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/scs)
 
 Python interface for [SCS](https://github.com/cvxgrp/scs) 3.0.0 and higher.


### PR DESCRIPTION
## Summary
- replace the Shields PyPI downloads badge with Pepy's public SVG badge endpoint
- make the badge label explicit as `PyPI downloads/month`
- link the badge to the Pepy project page

## Verification
- `curl -fsSL "https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads%2Fmonth"` renders SVG text `PyPI downloads/month` with the monthly download count