### PR TITLE
Expose acceleration_trust_factor in Python bindings

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -490,6 +490,7 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
                     "acceleration_type_1",
                     "acceleration_regularization",
                     "acceleration_relaxation",
+                    "acceleration_trust_factor",
                     "write_data_filename",
                     "log_csv_filename",
                     NULL};
@@ -499,15 +500,15 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
    on Windows where sizeof(long) < sizeof(long long) (LLP64 model). */
 #ifdef DLONG
 #ifdef SFLOAT
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LfffffffLLLffzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LfffffffLLLfffzz";
 #else
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LdddddddLLLddzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LdddddddLLLdddzz";
 #endif
 #else
 #ifdef SFLOAT
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!ifffffffiiiffzz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!ifffffffiiifffzz";
 #else
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!idddddddiiiddzz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!idddddddiiidddzz";
 #endif
 #endif
 
@@ -547,6 +548,7 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
           &(stgs->acceleration_type_1),
           &(stgs->acceleration_regularization),
           &(stgs->acceleration_relaxation),
+          &(stgs->acceleration_trust_factor),
           &(stgs->write_data_filename),
           &(stgs->log_csv_filename))) {
     /* PyArg_ParseTupleAndKeywords already set an informative TypeError
@@ -834,6 +836,16 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
       stgs->acceleration_relaxation > 2) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_relaxation must be in [0, 2]");
+  }
+  /* acceleration_trust_factor: INFINITY (default) disables; positive
+   * finite values turn on the trust-region + adaptive-r mode in aa.
+   * NaN and non-positive values are rejected. */
+  if (isnan((double)stgs->acceleration_trust_factor) ||
+      stgs->acceleration_trust_factor <= 0) {
+    free_py_scs_data(d, k, stgs, &ps);
+    return finish_with_error(
+        "acceleration_trust_factor must be positive (math.inf for no cap, "
+        "the default)");
   }
   if (!isfinite((double)stgs->scale) || stgs->scale <= 0) {
     free_py_scs_data(d, k, stgs, &ps);

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2779,6 +2779,32 @@ def test_acceleration_regularization_zero_allowed():
     assert sol["info"]["status"] in ("solved", "solved_inaccurate")
 
 
+def test_acceleration_trust_factor_default_inf():
+    """Default acceleration_trust_factor is +inf (no cap, current behavior)."""
+    solver = scs.SCS(_make_data(), _CONE, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+
+
+@pytest.mark.parametrize("trust_factor", [0.5, 1.0, 2.0, 10.0, float("inf")])
+def test_acceleration_trust_factor_in_range(trust_factor):
+    """Positive finite values enable trust-region + adaptive r; inf disables."""
+    solver = scs.SCS(
+        _make_data(), _CONE,
+        acceleration_trust_factor=trust_factor,
+        verbose=False,
+    )
+    sol = solver.solve()
+    assert sol["info"]["status"] in ("solved", "solved_inaccurate")
+
+
+@pytest.mark.parametrize("bad", [-1.0, 0.0, float("nan")])
+def test_acceleration_trust_factor_invalid_rejected(bad):
+    with pytest.raises(ValueError, match="acceleration_trust_factor"):
+        scs.SCS(_make_data(), _CONE,
+                acceleration_trust_factor=bad, verbose=False)
+
+
 # ===========================================================================
 # 73. Power cone with different exponents
 # ===========================================================================


### PR DESCRIPTION
## Summary

Plumbs the new `acceleration_trust_factor` setting (added in cvxgrp/scs#396) through the scs Python kwargs interface.

- Adds `acceleration_trust_factor` to the kwlist and argparse format in `scs/scsobject.h`
- Adds Python-side validation (rejects NaN / non-positive values)
- Bumps `scs_source` submodule to the corresponding scs branch
- Adds coverage tests for the default (`math.inf` = no cap, current HEAD behavior), a sweep of positive finite values, and rejection of bad inputs

The default is `math.inf` which preserves the current HEAD behavior bit-for-bit. Positive finite values turn on the trust-region + adaptive-r mode from the underlying [aa library](https://github.com/cvxgrp/aa) (PR #54 there), enabling parameter sweeps for further tuning.

## Test plan

- [x] `python -m pytest test/test_scs_coverage.py` — 286/286 pass
- [x] `python -m pytest test/test_scs_basic.py test/test_scs_object.py` — 26/26 pass
- [x] New trust_factor tests all pass (default, sweep, rejection)
- [x] Smoke-tested in REPL: default + explicit inf + finite values solve; 0 / -1 / NaN rejected

Depends on cvxgrp/scs#396 being merged before this can land cleanly.