### PR TITLE
[codex] Replace Node 20 MSVC setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Set up MSVC for Windows
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: egor-tensin/vs-shell@v2
 
       - name: Install conda on Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

Replace `ilammy/msvc-dev-cmd@v1` with the composite `egor-tensin/vs-shell@v2` action in the Windows wheel build workflow.

## Why

`ilammy/msvc-dev-cmd@v1` still declares a Node 20 runtime, and the latest checked release does not provide a Node 24 runtime. The replacement action is composite and sets up the Visual Studio shell without a Node runtime dependency.

## Validation

- Inspected workflow diff
- Ran `git diff --check`
- Verified changed workflow action metadata no longer reports `node20`