### PR TITLE
Fix build with use_gpu=true

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -288,6 +288,16 @@ endif
 if get_option('use_gpu')
   gpu_c_args = common_c_args + ['-DPY_GPU=1', '-DINDIRECT=1']
   _deps += cuda_dep
+  cublas_dep = cc.find_library('cublas', required: false)
+  if not cublas_dep.found()
+    cublas_dep = dependency('cublas', required: true)
+  endif
+  _deps += cublas_dep
+  cusparse_dep = cc.find_library('cusparse', required: false)
+  if not cusparse_dep.found()
+    cusparse_dep = dependency('cusparse', required: true)
+  endif
+  _deps += cusparse_dep
   if get_option('gpu_atrans')
     gpu_c_args += '-DGPU_TRANSPOSE_MAT=1'
   endif

--- a/meson.build
+++ b/meson.build
@@ -300,8 +300,8 @@ if get_option('use_gpu')
     # In Meson, sources with a `.cu` extension are compiled with nvcc by default.
     # To compile `.c` files with nvcc, they must be explicitly targeted.
     # It is strongly recommended to rename CUDA-C files to `.cu`.
-    fs.glob('scs_source/linsys/gpu/*.c'),
-    fs.glob('scs_source/linsys/gpu/indirect/*.c'),
+    'scs_source/linsys/gpu/gpu.c',
+    'scs_source/linsys/gpu/indirect/private.c',
     c_args: gpu_c_args,
     dependencies: _deps,
     include_directories: [


### PR DESCRIPTION
When building with `python -m pip install -Csetup-args=-Duse_gpu=true -Csetup-args=-Dint32=true .`, I get the error

```
      ../meson.build:303:7: ERROR: Unknown method 'glob' in object.
```

Indeed the [meson documentation for fs](https://mesonbuild.com/Fs-module.html) doesn't seem to have a glob function. The first commit unfurles the globs.

Next, when I run the `GPU_INDIRECT` solver, I get

```
ImportError: <...>/scs/_scs_gpu.cpython-314-x86_64-linux-gnu.so: undefined symbol: cusparseDestroySpMat
```

It seems it's not linked against `cusparse` (and `cublas`). The second commit adds these dependencies, and the solver runs in my testing. If I'm somehow building the library wrong, please let me know.

Fixes https://github.com/bodono/scs-python/issues/168. (While writing this PR I just noticed https://github.com/bodono/scs-python/issues/168#issuecomment-3834715573... :p)