### PR TITLE
Add adaptive_diag_scale setting binding

### DIFF
--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -477,6 +477,7 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
                     "verbose",
                     "normalize",
                     "adaptive_scale",
+                    "adaptive_diag_scale",
                     "max_iters",
                     "scale",
                     "eps_abs",
@@ -497,17 +498,19 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
 /* parse the arguments and ensure they are the correct type */
 /* Use 'L' (long long) for DLONG so that scs_int fields are parsed correctly
    on Windows where sizeof(long) < sizeof(long long) (LLP64 model). */
+/* adaptive_diag_scale is parsed as an integer (0/1); Python bools
+ * are accepted there too since bool subclasses int. */
 #ifdef DLONG
 #ifdef SFLOAT
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LfffffffLLLffzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LLfffffffLLLffzz";
 #else
-  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LdddddddLLLddzz";
+  char *argparse_string = "(LL)O!O!O!OOOO!O!O!|O!O!O!LLdddddddLLLddzz";
 #endif
 #else
 #ifdef SFLOAT
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!ifffffffiiiffzz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!iifffffffiiiffzz";
 #else
-  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!idddddddiiiddzz";
+  char *argparse_string = "(ii)O!O!O!OOOO!O!O!|O!O!O!iidddddddiiiddzz";
 #endif
 #endif
 
@@ -534,6 +537,7 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
           &PyBool_Type, &verbose,
           &PyBool_Type, &normalize,
           &PyBool_Type, &adaptive_scale,
+          &(stgs->adaptive_diag_scale),
           &(stgs->max_iters),
           &(stgs->scale),
           &(stgs->eps_abs),
@@ -865,6 +869,10 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
   if (!isfinite((double)stgs->rho_x) || stgs->rho_x <= 0) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("rho_x must be a positive finite number");
+  }
+  if (stgs->adaptive_diag_scale < 0 || stgs->adaptive_diag_scale > 1) {
+    free_py_scs_data(d, k, stgs, &ps);
+    return finish_with_error("adaptive_diag_scale must be 0 (off) or 1 (on)");
   }
   stgs->warm_start = WARM_START; /* False by default */
 

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2394,11 +2394,28 @@ def test_posinf_setting_rejected(field):
 @pytest.mark.parametrize(
     "field", ["eps_abs", "eps_rel", "eps_infeas", "time_limit_secs"]
 )
-def test_posinf_setting_accepted(field):
-    solver = scs.SCS(_make_data(), _CONE, verbose=False, max_iters=50,
-                     **{field: float("inf")})
+def test_posinf_setting_rejected(field):
+    # Upstream scs validates these fields with !isfinite (finite nonnegative
+    # required); inf is not a supported "no limit" sentinel. Use 0 to disable
+    # time_limit_secs / an eps component instead.
+    with pytest.raises(ValueError):
+        scs.SCS(_make_data(), _CONE, verbose=False, max_iters=50,
+                **{field: float("inf")})
+
+
+@pytest.mark.parametrize("level", [0, 1, False, True])
+def test_adaptive_diag_scale_accepted(level):
+    solver = scs.SCS(_make_data(), _CONE, verbose=False, max_iters=200,
+                     adaptive_diag_scale=level)
     sol = solver.solve()
     assert sol["info"]["status_val"] != 0  # some terminal status reached
+
+
+@pytest.mark.parametrize("level", [-1, 2, 3])
+def test_adaptive_diag_scale_rejected(level):
+    with pytest.raises(ValueError, match="adaptive_diag_scale"):
+        scs.SCS(_make_data(), _CONE, verbose=False,
+                adaptive_diag_scale=level)
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Binding for the `adaptive_diag_scale` solver setting as merged upstream (cvxgrp/scs#401, revised): integer **0 (off) / 1 (on — per-row dynamic rescaling, the upstream default)**, parsed as an int so Python bools are also accepted. Python-side validation mirrors the C-side check and message. Accept/reject coverage included.

> Note: the originally-proposed level 2 (rows+columns) was dropped upstream before merge — the column feedback destabilized (multiplier limit cycles); what shipped is rows-only, on by default.

## Pin

`scs_source` now points at current cvxgrp/scs master (`ab6daf72`), which includes the merged equilibration (#403), eigCG deflation (#407), CG retune (#408), and spectral projection fix (#411). The temporary `pin/scs-python-adaptive-diag-scale` branch is obsolete.

## Test-suite fix folded in

The four `test_posinf_setting_accepted` tests expected `inf` eps/time-limit sentinels from the `expose-aa-trust-factor` branch, which was closed (cvxgrp/scs#396 — trust region measured uniformly negative on the fixed base). Upstream validates those fields with `!isfinite`, so the tests now assert rejection; `time_limit_secs=0` remains the supported no-limit spelling.

## Testing

- Extension builds clean against the new pin (meson, macOS Accelerate).
- Full local suite: **390 passed, 66 skipped** (GPU/MKL skips), including the new binding tests and the flipped sentinel tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)