### PR TITLE
Bump version: 3.2.11 → 3.3.0, pin scs_source to scs 3.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.11
+current_version = 3.3.0
 
 [bumpversion:file:legacy_setup.py]
 

--- a/legacy_setup.py
+++ b/legacy_setup.py
@@ -310,7 +310,7 @@ def install_scs(**kwargs):
 
     setup(
         name="scs",
-        version="3.2.11",
+        version="3.3.0",
         author="Brendan O'Donoghue",
         author_email="bodonoghue85@gmail.com",
         url="http://github.com/cvxgrp/scs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = 'scs'
-version = "3.2.11"
+version = "3.3.0"
 description = 'Splitting conic solver'
 readme = 'README.md'
 requires-python = '>=3.9'


### PR DESCRIPTION
Version bump via `bumpversion minor` (legacy_setup.py, pyproject.toml) plus the `scs_source` submodule pinned to the scs 3.3.0 bump commit (cvxgrp/scs#416, `b99350d5`).

Verified locally against the new pin: extension builds clean, full test suite **390 passed / 66 skipped** (GPU/MKL skips).

Note: the pin references the #416 branch head — with the usual merge-commit workflow that sha becomes reachable from scs master once #416 merges, so merge #416 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)