### PR TITLE
Address 3.3.0 review: BLAS64 gating, infinity validation, lin_sys_solver, CI/test fixes

### DIFF
--- a/.github/scripts/mkl_guard.py
+++ b/.github/scripts/mkl_guard.py
@@ -1,0 +1,12 @@
+"""An ILP64 build must refuse to run in a process whose MKL (here NumPy's)
+is already LP64: the core's interface-layer guard fails construction, and
+prints why to stdout (the workflow greps for it)."""
+import numpy as np, scipy.sparse as sp, scs
+
+d = dict(P=sp.eye(2, format="csc"), A=sp.eye(2, format="csc"), b=np.ones(2), c=np.ones(2))
+try:
+    scs.SCS(d, dict(l=2), linear_solver=scs.LinearSolver.MKL, verbose=True)
+except ValueError as e:
+    print("guard refused construction:", e)
+else:
+    raise SystemExit("ILP64 build initialized against LP64 numpy-MKL: guard failed")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el -o pipefail {0}
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el -o pipefail {0}
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +105,7 @@ jobs:
             pixi r python .github/scripts/mkl_guard.py 2>&1 | tee /tmp/guard.log
             grep -q "MKL interface layer mismatch" /tmp/guard.log
           else
+            pixi r python -c "from scs import _scs_mkl"
             pixi r pytest
           fi
 
@@ -115,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el -o pipefail {0}
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el -o pipefail {0}
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +199,7 @@ jobs:
     runs-on: macos-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el -o pipefail {0}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.12" ]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: false
           pixi-version: v0.46.0
@@ -48,33 +48,38 @@ jobs:
           rm -rf build/
 
   build_mkl:
-    runs-on: ${{ matrix.os }}
+    # Source builds against conda-forge's dynamic MKL (link_mkl), one job per
+    # semantic case: an LP64 build solving under an MKL-backed NumPy; an
+    # ILP64 build refusing to share a process with that LP64 NumPy through
+    # the interface-layer guard; and an ILP64 build solving under an
+    # OpenBLAS NumPy, where no LP64 interface is preset.
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
-        link_mkl: [true]
-        use_blas64: [true, false]
-
+        include:
+          - case: lp64-solve
+            use_blas64: false
+            numpy_blas: mkl
+          - case: ilp64-guard
+            use_blas64: true
+            numpy_blas: mkl
+          - case: ilp64-solve
+            use_blas64: true
+            numpy_blas: openblas
+    name: build_mkl (${{ matrix.case }})
     env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      LINK_MKL: ${{ matrix.link_mkl }}
       USE_BLAS64: ${{ matrix.use_blas64 }}
+      NUMPY_BLAS: ${{ matrix.numpy_blas }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-
-      - name: Set Additional Envs
-        shell: bash
-        run: |
-          echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: false
           pixi-version: v0.46.0
@@ -83,12 +88,7 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: |
-          if [[ "$LINK_MKL" == "true" ]]; then
-            BLAS_PKGS="blas-devel=*=*mkl"
-          else
-            BLAS_PKGS="blas-devel=*=*openblas"
-          fi
-          pixi add --platform linux-64 $BLAS_PKGS pip scipy numpy pytest mkl mkl-devel pkg-config meson meson-python
+          pixi add --platform linux-64 "blas-devel=*=*${NUMPY_BLAS}" pip scipy numpy pytest mkl mkl-devel pkg-config meson meson-python python==3.12
       - name: Build
         run: |
           pixi r python -c "import numpy as np;print(np.show_config())"
@@ -99,8 +99,14 @@ jobs:
           pixi r python -m pip install --verbose --no-build-isolation $MESON_ARGS .
       - name: Test
         run: |
-          pixi r pytest
-          rm -rf build/
+          set -euo pipefail
+          export LD_LIBRARY_PATH="$(pwd)/.pixi/envs/default/lib:${LD_LIBRARY_PATH:-}"
+          if [ "${{ matrix.case }}" = ilp64-guard ]; then
+            pixi r python .github/scripts/mkl_guard.py 2>&1 | tee /tmp/guard.log
+            grep -q "MKL interface layer mismatch" /tmp/guard.log
+          else
+            pixi r pytest
+          fi
 
   build_gpu:
     # Build-only: linking against cuBLAS/cuSPARSE needs the CUDA toolkit but
@@ -119,7 +125,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: false
           pixi-version: v0.46.0
@@ -164,13 +170,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        native_arch: [true, false]
+        native_arch: [true]
 
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: false
           pixi-version: v0.46.0
@@ -196,13 +202,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.14" ]
 
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: false
           pixi-version: v0.46.0

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ additional backends can be enabled with build-time flags:
 # MKL Pardiso direct solver
 pip install . -Csetup-args=-Dlink_mkl=true
 
-# Use 64-bit BLAS/LAPACK integers (ILP64 / BLAS64)
-pip install . -Csetup-args=-Duse_blas64=true
+# Use 64-bit BLAS/LAPACK integers (ILP64 / BLAS64). Requires the MKL
+# backend (-Dlink_mkl=true): standard system BLAS (Accelerate/OpenBLAS)
+# is LP64 and the build rejects the combination as unsafe.
+pip install . -Csetup-args=-Dlink_mkl=true -Csetup-args=-Duse_blas64=true
 
 # GPU direct solver (cuDSS)
 pip install . -Csetup-args=-Dlink_cudss=true -Csetup-args=-Dint32=true
@@ -110,7 +112,7 @@ well for most problems, but the following settings can be tuned:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `acceleration_lookback` | `10` | AA memory size; `0` disables AA. |
-| `acceleration_interval` | `10` | Apply AA every N ADMM iterations. |
+| `acceleration_interval` | `5` | Apply AA every N ADMM iterations. |
 | `acceleration_type_1` | `1` | `1` = type-I AA, `0` = type-II AA. |
 | `acceleration_regularization` | `1e-8` | Tikhonov regularization for the AA least-squares solve. Tuned for type-I; type-II typically prefers `1e-12`. |
 | `acceleration_relaxation` | `1.0` | Relaxation factor in `[0, 2]`; `1.0` is vanilla AA. |

--- a/legacy_setup.py
+++ b/legacy_setup.py
@@ -202,7 +202,8 @@ def install_scs(**kwargs):
     if args.extraverbose:
         define_macros += [("VERBOSITY", 999)]  # for debugging
     if args.blas64:
-        define_macros += [("BLAS64", 1)]  # 64 bit blas
+        raise SystemExit("--blas64 is not supported by legacy_setup.py; use meson: "
+                         "pip install . -Csetup-args=-Duse_blas64=true -Csetup-args=-Dlink_mkl=true")
     if not args.int32 and not args.gpu:
         define_macros += [("DLONG", 1)]  # longs for integer type
 

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,12 @@ if get_option('use_singleprec')
 endif
 
 if get_option('use_blas64')
+  if not get_option('link_mkl')
+    # Declaring 64-bit BLAS integers while linking an LP64 BLAS (the standard
+    # Accelerate/OpenBLAS builds) corrupts every BLAS call; only the MKL ILP64
+    # configuration is verified.
+    error('use_blas64=true requires link_mkl=true (ILP64 MKL).')
+  endif
   common_c_args += '-DBLAS64=1'
 endif
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ testpaths = [
     "test",
 ]
 faulthandler_timeout = 600
-faulthandler_exit_on_timeout = true
 markers = [
     "thread_unsafe: mark test as unsafe to run in parallel threads (pytest-run-parallel)",
 ]

--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -827,6 +827,9 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_interval must be positive");
   }
+  /* TODO(repin): the core's sign contract (negative = pinned absolute
+   * value, cvxgrp/scs#421) is not in the pinned core yet; drop `< 0`
+   * with the submodule bump. */
   if (!isfinite((double)stgs->acceleration_regularization) ||
       stgs->acceleration_regularization < 0) {
     free_py_scs_data(d, k, stgs, &ps);
@@ -843,24 +846,24 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("scale must be a positive finite number");
   }
-  /* time_limit_secs: 0 disables the limit, +inf is equivalent, both allowed. */
-  if (isnan((double)stgs->time_limit_secs) || stgs->time_limit_secs < 0) {
+  /* Match the core (!isfinite): +inf is rejected; 0 disables the limit. */
+  if (!isfinite((double)stgs->time_limit_secs) || stgs->time_limit_secs < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("time_limit_secs must be nonnegative");
+    return finish_with_error(
+        "time_limit_secs must be a nonnegative finite number (0 disables)");
   }
-  /* eps_*: +inf is allowed (effectively disables that stopping criterion);
-   * NaN is not — it would make every tolerance comparison false. */
-  if (isnan((double)stgs->eps_abs) || stgs->eps_abs < 0) {
+  if (!isfinite((double)stgs->eps_abs) || stgs->eps_abs < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_abs must be nonnegative");
+    return finish_with_error("eps_abs must be a nonnegative finite number");
   }
-  if (isnan((double)stgs->eps_rel) || stgs->eps_rel < 0) {
+  if (!isfinite((double)stgs->eps_rel) || stgs->eps_rel < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_rel must be nonnegative");
+    return finish_with_error("eps_rel must be a nonnegative finite number");
   }
-  if (isnan((double)stgs->eps_infeas) || stgs->eps_infeas < 0) {
+  if (!isfinite((double)stgs->eps_infeas) || stgs->eps_infeas < 0) {
     free_py_scs_data(d, k, stgs, &ps);
-    return finish_with_error("eps_infeas must be nonnegative");
+    return finish_with_error(
+        "eps_infeas must be a nonnegative finite number");
   }
   if (!isfinite((double)stgs->alpha) || stgs->alpha <= 0 || stgs->alpha >= 2) {
     free_py_scs_data(d, k, stgs, &ps);
@@ -1038,21 +1041,21 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
 #ifdef DLONG
 #ifdef SFLOAT
   char *outarg_string = "{s:L,s:L,s:L,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,"
-                        "s:f,s:f,s:f,s:f,s:f,s:L,s:L,s:s}";
+                        "s:f,s:f,s:f,s:f,s:f,s:L,s:L,s:s,s:s}";
   char *aa_stats_string = "{s:L,s:L,s:L,s:L,s:L,s:L,s:L,s:L,s:f,s:f}";
 #else
   char *outarg_string = "{s:L,s:L,s:L,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,"
-                        "s:d,s:d,s:d,s:d,s:d,s:L,s:L,s:s}";
+                        "s:d,s:d,s:d,s:d,s:d,s:L,s:L,s:s,s:s}";
   char *aa_stats_string = "{s:L,s:L,s:L,s:L,s:L,s:L,s:L,s:L,s:d,s:d}";
 #endif
 #else
 #ifdef SFLOAT
   char *outarg_string = "{s:i,s:i,s:i,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,s:f,"
-                        "s:f,s:f,s:f,s:f,s:f,s:i,s:i,s:s}";
+                        "s:f,s:f,s:f,s:f,s:f,s:i,s:i,s:s,s:s}";
   char *aa_stats_string = "{s:i,s:i,s:i,s:i,s:i,s:i,s:i,s:i,s:f,s:f}";
 #else
   char *outarg_string = "{s:i,s:i,s:i,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,"
-                        "s:d,s:d,s:d,s:d,s:d,s:i,s:i,s:s}";
+                        "s:d,s:d,s:d,s:d,s:d,s:i,s:i,s:s,s:s}";
   char *aa_stats_string = "{s:i,s:i,s:i,s:i,s:i,s:i,s:i,s:i,s:d,s:d}";
 #endif
 #endif
@@ -1081,7 +1084,8 @@ static PyObject *SCS_solve(SCS *self, PyObject *args) {
       "accel_time", (scs_float)(info.accel_time),
       "rejected_accel_steps", (scs_int)info.rejected_accel_steps,
       "accepted_accel_steps", (scs_int)info.accepted_accel_steps,
-      "status", info.status);
+      "status", info.status,
+      "lin_sys_solver", info.lin_sys_solver);
   aa_stats_dict = Py_BuildValue(
       aa_stats_string,
       "iter", (scs_int)info.aa_stats.iter,

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2389,16 +2389,15 @@ def test_posinf_setting_rejected(field):
                 **{field: float("inf")})
 
 
-# +inf on eps_* and time_limit_secs is semantically meaningful (disables
-# that stopping criterion / time limit) and must still be accepted.
+# +inf on eps_* and time_limit_secs is rejected like every other
+# non-finite setting (the core validates with !isfinite; the wrapper mirrors
+# it with setting-specific messages). Use time_limit_secs=0 to disable the
+# limit and a large finite eps to disable a criterion.
 @pytest.mark.parametrize(
     "field", ["eps_abs", "eps_rel", "eps_infeas", "time_limit_secs"]
 )
-def test_posinf_setting_rejected(field):
-    # Upstream scs validates these fields with !isfinite (finite nonnegative
-    # required); inf is not a supported "no limit" sentinel. Use 0 to disable
-    # time_limit_secs / an eps component instead.
-    with pytest.raises(ValueError):
+def test_posinf_tolerance_rejected(field):
+    with pytest.raises(ValueError, match=field):
         scs.SCS(_make_data(), _CONE, verbose=False, max_iters=50,
                 **{field: float("inf")})
 

--- a/test/test_solve_random_cone_prob_mkl.py
+++ b/test/test_solve_random_cone_prob_mkl.py
@@ -44,6 +44,7 @@ def test_solve_feasible():
     data, p_star = tools.gen_feasible(K, n=m // 3, density=0.1, rng=rng)
     solver = scs.SCS(data, K, linear_solver=scs.LinearSolver.MKL, **params)
     sol = solver.solve()
+    assert sol["info"]["lin_sys_solver"] == "sparse-direct-mkl-pardiso"
     x = sol["x"]
     y = sol["y"]
     s = sol["s"]


### PR DESCRIPTION
Batch of the scs-python findings from the 3.3.0 review, excluding the removed-kwargs shim (intentionally skipped) and the SIGINT interrupt manager (separate PR):

- **BLAS64 gating**: `use_blas64=true` without `link_mkl=true` declared ILP64 integer widths against LP64 system BLAS — memory corruption by configuration (the review measured 20 spectral failures under Accelerate). Meson now rejects the combination with a clear error; README example fixed.
- **Infinity validation aligned with core**: the wrapper admitted +inf for `eps_*`/`time_limit_secs` that core then rejected with a misleading generic error. The wrapper now mirrors core's `!isfinite` with per-setting messages (`time_limit_secs=0` remains the no-limit spelling).
- **`info['lin_sys_solver']` exposed** — with AUTO choosing invisibly (and preferring MKL in standard wheels), the chosen backend is now inspectable (verified: returns e.g. `'sparse-direct-amd-qdldl'`).
- **README**: AUTO/MKL upgrade-behavior disclosure with pinning guidance; `acceleration_interval` default corrected to 5.
- **Duplicate test name fixed**: the shadowed scale/rho_x/alpha +inf rejection tests run again.
- **CI**: the source-MKL job runs three semantic cases (an LP64 build solving under an MKL-backed NumPy, an ILP64 build hitting the interface-layer guard under that same NumPy, an ILP64 build solving under an OpenBLAS NumPy) instead of every Python version times both widths; the OpenMP, Accelerate and native-arch source lanes run one configuration each, the wheel matrix covers every Python ABI. Unrecognized pytest option dropped.

Stacked on #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
