### PR TITLE
Share interrupt state across all SCS extensions (fixes swallowed SIGINT)

### DIFF
--- a/legacy_setup.py
+++ b/legacy_setup.py
@@ -184,8 +184,10 @@ def install_scs(**kwargs):
     extra_link_args = []
     libraries = []
     sources = (
-        ["scs/scspy.c"]
-        + glob("scs_source/src/*.c")
+        ["scs/scspy.c", "scs/py_ctrlc.c"]
+        # Python builds share one process-wide interrupt state (scs/py_ctrlc.c)
+        # instead of the upstream per-extension ctrlc.c
+        + [f for f in glob("scs_source/src/*.c") if not f.endswith("ctrlc.c")]
         + glob("scs_source/linsys/*.c")
     )
     include_dirs = ["scs_source/include", "scs_source/linsys"]

--- a/meson.build
+++ b/meson.build
@@ -209,7 +209,7 @@ endif
 scs_core_sources = files(
   'scs_source/src/aa.c',
   'scs_source/src/cones.c',
-  'scs_source/src/ctrlc.c',
+  'scs/py_ctrlc.c',
   'scs_source/src/exp_cone.c',
   'scs_source/src/linalg.c',
   'scs_source/src/normalize.c',

--- a/scs/py_ctrlc.c
+++ b/scs/py_ctrlc.c
@@ -25,6 +25,7 @@ typedef struct {
   volatile LONG int_detected;
   CRITICAL_SECTION cs;
   int listener_count;
+  PHANDLER_ROUTINE handler;
 } scs_py_interrupt_state;
 #define SCS_PY_LOCK(s) EnterCriticalSection(&(s)->cs)
 #define SCS_PY_UNLOCK(s) LeaveCriticalSection(&(s)->cs)
@@ -105,7 +106,8 @@ void scs_start_interrupt_listener(void) {
   SCS_PY_LOCK(s);
   if (s->listener_count++ == 0) {
     InterlockedExchange(&s->int_detected, 0);
-    SetConsoleCtrlHandler(scs_handle_ctrlc, TRUE);
+    s->handler = scs_handle_ctrlc;
+    SetConsoleCtrlHandler(s->handler, TRUE);
   }
   SCS_PY_UNLOCK(s);
 }
@@ -114,7 +116,9 @@ void scs_end_interrupt_listener(void) {
   scs_py_interrupt_state *s = shared_state;
   SCS_PY_LOCK(s);
   if (s->listener_count > 0 && --s->listener_count == 0) {
-    SetConsoleCtrlHandler(scs_handle_ctrlc, FALSE);
+    /* The last solver may belong to a different extension, whose static
+     * handler has a different address. Remove the one we installed. */
+    SetConsoleCtrlHandler(s->handler, FALSE);
   }
   SCS_PY_UNLOCK(s);
 }

--- a/scs/py_ctrlc.c
+++ b/scs/py_ctrlc.c
@@ -1,0 +1,159 @@
+/*
+ * Process-shared interrupt (ctrl-c) state for the SCS Python extensions,
+ * replacing scs_source/src/ctrlc.c in Python builds.
+ *
+ * Each extension compiles its own copy of the solver; with per-extension
+ * static state, overlapping solves from two extensions restored the SIGINT
+ * handler non-LIFO and left a dead SCS handler installed, swallowing SIGINT
+ * for the rest of the process. One state struct per process is published as
+ * a PyCapsule in a registry module's dict (PyDict_SetDefault, so racing
+ * imports agree on it); each extension resolves it once at import time. The
+ * solver-facing functions touch no Python API (they run with the GIL
+ * released). The registry dict keeps the capsule alive forever, so the
+ * borrowed reference PyDict_SetDefault returns is stable.
+ */
+
+#include "ctrlc.h"
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stdlib.h>
+
+#if (defined _WIN32 || defined _WIN64 || defined _WINDLL)
+#include <windows.h>
+typedef struct {
+  volatile LONG int_detected;
+  CRITICAL_SECTION cs;
+  int listener_count;
+} scs_py_interrupt_state;
+#define SCS_PY_LOCK(s) EnterCriticalSection(&(s)->cs)
+#define SCS_PY_UNLOCK(s) LeaveCriticalSection(&(s)->cs)
+#else
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+typedef struct {
+  /* written by the signal handler, read by every solving thread: a C11
+   * atomic is both signal-safe and thread-safe (volatile sig_atomic_t is
+   * only the former, and TSan flags it under free-threading) */
+  atomic_int int_detected;
+  struct sigaction oact;
+  pthread_mutex_t mutex;
+  int listener_count;
+} scs_py_interrupt_state;
+#define SCS_PY_LOCK(s) pthread_mutex_lock(&(s)->mutex)
+#define SCS_PY_UNLOCK(s) pthread_mutex_unlock(&(s)->mutex)
+#endif
+
+#define SCS_CTRLC_REGISTRY "_scs_interrupt_registry"
+#define SCS_CTRLC_CAPSULE "scs_interrupt_state_v1"
+
+static scs_py_interrupt_state *shared_state = NULL;
+
+/* Called from each extension's module init with the GIL held. Idempotent;
+ * racing imports agree on one state struct. Returns 0 on success. */
+int scs_py_ctrlc_init(void) {
+  PyObject *registry, *dict, *key, *capsule, *winner;
+  scs_py_interrupt_state *state;
+  if (shared_state) {
+    return 0;
+  }
+  registry = PyImport_AddModule(SCS_CTRLC_REGISTRY);
+  if (!registry) {
+    return -1;
+  }
+  dict = PyModule_GetDict(registry); /* borrowed */
+  state = (scs_py_interrupt_state *)calloc(1, sizeof(*state));
+  if (!state) {
+    PyErr_NoMemory();
+    return -1;
+  }
+#if (defined _WIN32 || defined _WIN64 || defined _WINDLL)
+  InitializeCriticalSection(&state->cs);
+#else
+  pthread_mutex_init(&state->mutex, NULL);
+  atomic_init(&state->int_detected, 0);
+#endif
+  capsule = PyCapsule_New(state, SCS_CTRLC_CAPSULE, NULL);
+  key = PyUnicode_FromString(SCS_CTRLC_CAPSULE);
+  winner = (capsule && key) ? PyDict_SetDefault(dict, key, capsule) : NULL;
+  Py_XDECREF(key);
+  if (winner && winner != capsule) {
+    free(state); /* another extension's import won the race */
+  }
+  Py_XDECREF(capsule); /* the registry dict holds the winning capsule */
+  if (!winner) {
+    return -1;
+  }
+  shared_state =
+      (scs_py_interrupt_state *)PyCapsule_GetPointer(winner, SCS_CTRLC_CAPSULE);
+  return shared_state ? 0 : -1;
+}
+
+#if (defined _WIN32 || defined _WIN64 || defined _WINDLL)
+
+static BOOL WINAPI scs_handle_ctrlc(DWORD dwCtrlType) {
+  if (dwCtrlType != CTRL_C_EVENT) {
+    return FALSE;
+  }
+  InterlockedExchange(&shared_state->int_detected, 1);
+  return TRUE;
+}
+
+void scs_start_interrupt_listener(void) {
+  scs_py_interrupt_state *s = shared_state;
+  SCS_PY_LOCK(s);
+  if (s->listener_count++ == 0) {
+    InterlockedExchange(&s->int_detected, 0);
+    SetConsoleCtrlHandler(scs_handle_ctrlc, TRUE);
+  }
+  SCS_PY_UNLOCK(s);
+}
+
+void scs_end_interrupt_listener(void) {
+  scs_py_interrupt_state *s = shared_state;
+  SCS_PY_LOCK(s);
+  if (s->listener_count > 0 && --s->listener_count == 0) {
+    SetConsoleCtrlHandler(scs_handle_ctrlc, FALSE);
+  }
+  SCS_PY_UNLOCK(s);
+}
+
+int scs_is_interrupted(void) {
+  return (int)InterlockedCompareExchange(&shared_state->int_detected, 0, 0);
+}
+
+#else /* POSIX */
+
+static void scs_handle_ctrlc(int sig) {
+  atomic_store(&shared_state->int_detected, sig ? sig : -1);
+}
+
+void scs_start_interrupt_listener(void) {
+  scs_py_interrupt_state *s = shared_state;
+  SCS_PY_LOCK(s);
+  if (s->listener_count++ == 0) {
+    struct sigaction act;
+    atomic_store(&s->int_detected, 0);
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    act.sa_handler = scs_handle_ctrlc;
+    sigaction(SIGINT, &act, &s->oact);
+  }
+  SCS_PY_UNLOCK(s);
+}
+
+void scs_end_interrupt_listener(void) {
+  scs_py_interrupt_state *s = shared_state;
+  SCS_PY_LOCK(s);
+  if (s->listener_count > 0 && --s->listener_count == 0) {
+    sigaction(SIGINT, &s->oact, NULL);
+  }
+  SCS_PY_UNLOCK(s);
+}
+
+int scs_is_interrupted(void) {
+  return (int)atomic_load(&shared_state->int_detected);
+}
+
+#endif

--- a/scs/scsmodule.h
+++ b/scs/scsmodule.h
@@ -1,6 +1,9 @@
 #ifndef PY_SCSMODULE_H
 #define PY_SCSMODULE_H
 
+/* from scs/py_ctrlc.c */
+extern int scs_py_ctrlc_init(void);
+
 static PyObject *version(PyObject *self) {
   return Py_BuildValue("s", scs_version());
 }
@@ -71,14 +74,26 @@ static PyObject *moduleinit(void) {
   /* Initialize SCS_Type */
   SCS_Type.tp_new = PyType_GenericNew;
   if (PyType_Ready(&SCS_Type) < 0)
-    return NULL;
+    goto fail;
 
   /* Add type to the module dictionary and initialize it */
   Py_INCREF(&SCS_Type);
-  if (PyModule_AddObject(m, "SCS", (PyObject *)&SCS_Type) < 0)
-    return NULL;
+  if (PyModule_AddObject(m, "SCS", (PyObject *)&SCS_Type) < 0) {
+    Py_DECREF(&SCS_Type);
+    goto fail;
+  }
+
+  /* Join (or create) the process-shared interrupt state; see
+   * scs/py_ctrlc.c. Must run while the GIL is held. */
+  if (scs_py_ctrlc_init() < 0)
+    goto fail;
 
   return m;
+
+fail:
+  /* every failure exit after PyModule_Create must release the module */
+  Py_DECREF(m);
+  return NULL;
 };
 
 #if PY_MAJOR_VERSION >= 3

--- a/test/test_sigint_mixed_backends.py
+++ b/test/test_sigint_mixed_backends.py
@@ -1,0 +1,82 @@
+"""One SIGINT must interrupt overlapping solves from two different
+extensions, and Python's handler must be back afterwards (scs/py_ctrlc.c)."""
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX signal semantics"
+)
+
+_COMMON = r"""
+import threading, os, signal, time
+import numpy as np, scipy.sparse as sp
+import scs
+
+def make(n=600):
+    rng = np.random.RandomState(0)
+    P = sp.csc_matrix(np.eye(n))
+    A = sp.vstack([sp.eye(n), sp.csc_matrix(rng.randn(n // 2, n))]).tocsc()
+    return (dict(P=P, A=A, b=np.ones(A.shape[0]), c=rng.randn(n)),
+            dict(l=A.shape[0]))
+
+DATA, CONE = make()
+
+def make_solver(backend, max_iters, eps):
+    # construct in the main thread (numpy/scipy conversions race under
+    # free-threading); threads then call only solve()
+    return scs.SCS(DATA, CONE, linear_solver=backend, verbose=False,
+                   max_iters=max_iters, eps_abs=eps, eps_rel=eps)
+"""
+
+
+def _run(body):
+    return subprocess.run(
+        [sys.executable, "-c", _COMMON + body],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+def test_sigint_during_and_after_mixed_backend_overlap():
+    body = r"""
+results = {}
+start_barrier = threading.Barrier(3)
+
+# Construct both solvers in the main thread (see make_solver note);
+# eps 0 cannot be met, so the solves can only end via the interrupt.
+solvers = {
+    "a": make_solver(scs.LinearSolver.QDLDL, max_iters=10**9, eps=0.0),
+    "b": make_solver(scs.LinearSolver.CPU_INDIRECT, max_iters=10**9, eps=0.0),
+}
+
+def bg(name):
+    start_barrier.wait()  # synchronize solver startup with the signaler
+    results[name] = solvers[name].solve()
+
+t1 = threading.Thread(target=bg, args=("a",))
+t2 = threading.Thread(target=bg, args=("b",))
+t1.start(); t2.start()
+start_barrier.wait()
+time.sleep(1.0)  # both threads are well inside scs_solve by now
+os.kill(os.getpid(), signal.SIGINT)
+try:
+    t1.join(timeout=60); t2.join(timeout=60)
+except KeyboardInterrupt:
+    t1.join(timeout=60); t2.join(timeout=60)
+
+ok = len(results) == 2 and all(r["info"]["status_val"] == scs.SIGINT for r in results.values())
+print("BOTH_INTERRUPTED" if ok else f"BAD: {results}")
+# and the handler must be Python's again afterwards
+try:
+    os.kill(os.getpid(), signal.SIGINT)
+    time.sleep(1.0)
+    print("SWALLOWED")
+except KeyboardInterrupt:
+    print("RESTORED")
+"""
+    r = _run(body)
+    assert r.returncode == 0, (r.stdout, r.stderr)
+    assert "BOTH_INTERRUPTED" in r.stdout and "RESTORED" in r.stdout, (
+        r.stdout, r.stderr)
+

--- a/test/test_sigint_mixed_backends.py
+++ b/test/test_sigint_mixed_backends.py
@@ -5,10 +5,6 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="POSIX signal semantics"
-)
-
 _COMMON = r"""
 import threading, os, signal, time
 import numpy as np, scipy.sparse as sp
@@ -31,13 +27,14 @@ def make_solver(backend, max_iters, eps):
 """
 
 
-def _run(body):
+def _run(body, **kwargs):
     return subprocess.run(
         [sys.executable, "-c", _COMMON + body],
-        capture_output=True, text=True, timeout=120,
+        capture_output=True, text=True, timeout=120, **kwargs,
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
 def test_sigint_during_and_after_mixed_backend_overlap():
     body = r"""
 results = {}
@@ -80,3 +77,60 @@ except KeyboardInterrupt:
     assert "BOTH_INTERRUPTED" in r.stdout and "RESTORED" in r.stdout, (
         r.stdout, r.stderr)
 
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows console handlers")
+def test_windows_handler_removed_after_non_lifo_overlap():
+    body = r"""
+import ctypes, sys
+
+solvers = {
+    "a": scs.SCS(DATA, CONE, linear_solver=scs.LinearSolver.QDLDL,
+                 verbose=True, max_iters=1),
+    "b": scs.SCS(DATA, CONE, linear_solver=scs.LinearSolver.CPU_INDIRECT,
+                 verbose=True, max_iters=1),
+}
+entered = {name: threading.Event() for name in solvers}
+release = {name: threading.Event() for name in solvers}
+output = sys.stdout
+
+class Gate:
+    def write(self, text):
+        name = threading.current_thread().name
+        if name in entered and not entered[name].is_set():
+            # scs_solve prints its header after installing the listener.
+            # Pause here to enforce A-start, B-start, A-end, B-end exactly.
+            entered[name].set()
+            assert release[name].wait(30), "solver release timed out"
+        return output.write(text)
+
+    def flush(self):
+        output.flush()
+
+sys.stdout = Gate()
+threads = {
+    name: threading.Thread(name=name, target=solver.solve, daemon=True)
+    for name, solver in solvers.items()
+}
+for name, thread in threads.items():
+    thread.start()
+    assert entered[name].wait(30), f"{name} did not enter scs_solve"
+for name, thread in threads.items():
+    release[name].set()
+    thread.join(30)
+    assert not thread.is_alive(), f"{name} did not finish"
+sys.stdout = output
+
+# This child has its own console: the event cannot reach pytest or its runner.
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+try:
+    if not kernel32.GenerateConsoleCtrlEvent(signal.CTRL_C_EVENT, 0):
+        raise ctypes.WinError(ctypes.get_last_error())
+    time.sleep(5)
+except KeyboardInterrupt:
+    print("RESTORED")
+else:
+    raise AssertionError("SCS swallowed Ctrl+C after both solves finished")
+"""
+    r = _run(body, creationflags=subprocess.CREATE_NEW_CONSOLE)
+    assert r.returncode == 0, (r.stdout, r.stderr)
+    assert "RESTORED" in r.stdout, (r.stdout, r.stderr)


### PR DESCRIPTION
Fixes the highest-severity scs-python finding from the 3.3.0 review, reproduced exactly as described: after overlapping QDLDL and CPU_INDIRECT solves, a self-sent SIGINT was permanently swallowed.

**Mechanism**: each extension compiles its own `ctrlc.c`, so saved-handler/refcount state is per-extension. Non-LIFO overlap makes extension B save A's transient handler as "previous" and restore it last — a dead SCS handler stays installed forever.

**Fix**: Python builds swap `scs_source/src/ctrlc.c` for `scs/py_ctrlc.c` (same three-function interface, vendored source untouched) operating on one process-shared state struct, published as a PyCapsule via atomic `PyDict_SetDefault` insert-if-absent (race-safe under free-threading), resolved once per extension at import with the GIL held. One shared refcount ⟹ the real previous handler is saved once and restored once, however solves interleave. POSIX + Windows.

**Test** (subprocess-based, POSIX): one barrier-synchronised reproduction overlaps a QDLDL and a CPU_INDIRECT solve, sends SIGINT during the overlap, and checks that both solves stop and the original handler is back afterwards; before the fix the handler was swallowed.

Stacked on #230 (shares meson.build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
