### PR TITLE
Bump to 3.3.1 and update the SCS core submodule

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 
 [bumpversion:file:legacy_setup.py]
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ well for most problems, but the following settings can be tuned:
 | `acceleration_lookback` | `10` | AA memory size; `0` disables AA. |
 | `acceleration_interval` | `5` | Apply AA every N ADMM iterations. |
 | `acceleration_type_1` | `1` | `1` = type-I AA, `0` = type-II AA. |
-| `acceleration_regularization` | `1e-8` | Tikhonov regularization for the AA least-squares solve. Tuned for type-I; type-II typically prefers `1e-12`. |
+| `acceleration_regularization` | `1e-8` | Tikhonov regularization for the AA least-squares solve; a negative value pins its absolute value. Tuned for type-I; type-II typically prefers `1e-12`. |
 | `acceleration_relaxation` | `1.0` | Relaxation factor in `[0, 2]`; `1.0` is vanilla AA. |
 
 ```python

--- a/legacy_setup.py
+++ b/legacy_setup.py
@@ -313,7 +313,7 @@ def install_scs(**kwargs):
 
     setup(
         name="scs",
-        version="3.3.0",
+        version="3.3.1",
         author="Brendan O'Donoghue",
         author_email="bodonoghue85@gmail.com",
         url="http://github.com/cvxgrp/scs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = 'scs'
-version = "3.3.0"
+version = "3.3.1"
 description = 'Splitting conic solver'
 readme = 'README.md'
 requires-python = '>=3.9'

--- a/scs/scsobject.h
+++ b/scs/scsobject.h
@@ -827,14 +827,11 @@ static int SCS_init(SCS *self, PyObject *args, PyObject *kwargs) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error("acceleration_interval must be positive");
   }
-  /* TODO(repin): the core's sign contract (negative = pinned absolute
-   * value, cvxgrp/scs#421) is not in the pinned core yet; drop `< 0`
-   * with the submodule bump. */
-  if (!isfinite((double)stgs->acceleration_regularization) ||
-      stgs->acceleration_regularization < 0) {
+  /* Negative regularization pins its absolute value. */
+  if (!isfinite((double)stgs->acceleration_regularization)) {
     free_py_scs_data(d, k, stgs, &ps);
     return finish_with_error(
-        "acceleration_regularization must be a nonnegative finite number");
+        "acceleration_regularization must be a finite number");
   }
   if (!isfinite((double)stgs->acceleration_relaxation) ||
       stgs->acceleration_relaxation < 0 ||

--- a/test/test_scs_coverage.py
+++ b/test/test_scs_coverage.py
@@ -2780,11 +2780,21 @@ def test_acceleration_relaxation_out_of_range_rejected(bad):
                 acceleration_relaxation=bad, verbose=False)
 
 
-@pytest.mark.parametrize("bad", [-1e-12, float("nan"), float("inf")])
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf")])
 def test_acceleration_regularization_invalid_rejected(bad):
     with pytest.raises(ValueError, match="acceleration_regularization"):
         scs.SCS(_make_data(), _CONE,
                 acceleration_regularization=bad, verbose=False)
+
+
+@pytest.mark.parametrize("aa_type", [0, 1])
+def test_acceleration_regularization_negative_pins_and_solves(aa_type):
+    solver = scs.SCS(_make_data(), _CONE, acceleration_type_1=aa_type,
+                     acceleration_interval=1,
+                     acceleration_regularization=-1e-8, verbose=False)
+    sol = solver.solve()
+    assert sol["info"]["status_val"] == scs.SOLVED
+    assert_almost_equal(sol["x"], [1.0], decimal=3)
 
 
 def test_acceleration_regularization_zero_allowed():


### PR DESCRIPTION
## Summary

- Bump the Python package metadata and legacy setup entry point to 3.3.1.
- Update `scs_source` to the final, merged SCS 3.3.1 commit `cc244ebc4bff620e2e228e99a4e2e24ab12f9e3b` (cvxgrp/scs#426).
- Remove the temporary nonnegative-only regularization restriction now that the pinned core supports negative values as pinned absolute regularization. Document the contract and test real solves for type-I and type-II acceleration, while rejecting NaN and both infinities.

All feature PRs are merged and their final merged-branch CI is green. The final core release commit is also green. Tagging and PyPI publication remain gated on this PR and its merged-branch CI, including the MKL and wheel checks.

## Validation

- Built and installed an actual CPython 3.14 macOS arm64 wheel.
- Runtime `scs.__version__`, installed distribution metadata, and wheel metadata all report 3.3.1.
- Full local test suite against the installed wheel: 396 passed, 67 platform/optional-feature skips.
- Built the sdist, checked its core contents, and successfully rebuilt a wheel from that sdist.
- Exact core gitlink and clean `git diff --check` verified.

Linux MKL, Windows, free-threading, and the complete release wheel matrix remain covered by CI; these were not run locally on this Mac.
